### PR TITLE
Refactor buildSite() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,25 @@
 {
-    "name": "jigsaw/jigsaw",
+    "name": "cambri/jigsaw",
     "description": "Simple static sites with Laravel's Blade.",
-    "keywords": ["blade", "laravel", "static", "site", "generator"],
+    "keywords": ["blade", "laravel 4", "static", "site", "generator"],
     "license": "MIT",
     "authors": [
         {
             "name": "Adam Wathan",
             "email": "adam.wathan@gmail.com"
+        },
+        {
+            "name": "Carl Price",
+            "email": "cambricorp@gmail.com"
         }
     ],
     "autoload": {
         "psr-4": {
-            "Jigsaw\\Jigsaw\\": "src"
+            "Cambri\\Jigsaw\\": "src"
         }
     },
     "require": {
-        "illuminate/container": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/view": "~5.0",
-        "symfony/console": "~2.5",
+        "php": ">=5.4.0",
         "mockery/mockery": "^0.9.4"
     },
     "bin": [

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1,7 +1,7 @@
-<?php namespace Jigsaw\Jigsaw\Console;
+<?php namespace Cambri\Jigsaw\Console;
 
 use Illuminate\Filesystem\Filesystem;
-use Jigsaw\Jigsaw\Jigsaw;
+use Cambri\Jigsaw\Jigsaw;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,7 +1,7 @@
-<?php namespace Jigsaw\Jigsaw\Console;
+<?php namespace Cambri\Jigsaw\Console;
 
 use Illuminate\Filesystem\Filesystem;
-use Jigsaw\Jigsaw\Jigsaw;
+use Cambri\Jigsaw\Jigsaw;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -1,4 +1,4 @@
-<?php namespace Jigsaw\Jigsaw\Console;
+<?php namespace Cambri\Jigsaw\Console;
 
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -1,7 +1,7 @@
-<?php namespace Jigsaw\Jigsaw\Handlers;
+<?php namespace Cambri\Jigsaw\Handlers;
 
-use Illuminate\Contracts\View\Factory;
-use Jigsaw\Jigsaw\ProcessedFile;
+use Illuminate\View\Factory;
+use Cambri\Jigsaw\ProcessedFile;
 
 class BladeHandler
 {

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -1,8 +1,8 @@
-<?php namespace Jigsaw\Jigsaw\Handlers;
+<?php namespace Cambri\Jigsaw\Handlers;
 
-use Illuminate\Contracts\View\Factory;
+use Illuminate\View\Factory;
 use Illuminate\Filesystem\Filesystem;
-use Jigsaw\Jigsaw\ProcessedFile;
+use Cambri\Jigsaw\ProcessedFile;
 
 class DefaultHandler
 {

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -55,12 +55,24 @@ class Jigsaw
     }
 
     private function buildSite($source, $dest, $config)
-    {
-        collect($this->files->allFiles($source))->filter(function ($file) {
-            return ! $this->shouldIgnore($file);
-        })->each(function ($file) use ($dest, $config) {
-            $this->buildFile($file, $dest, $config);
-        });
+    {   
+        // Get all files
+        $files = $this->files->allFiles($source);
+
+        // Make a new collection
+        $collection = new Collection($files);
+
+        // Filter the collection for ignored resources (ie directories, files, sensitivities)
+        foreach($files as $file){
+          
+          // Use collection class methods to filter the files
+          $collection->filter(function ($file) {
+              return ! $this->shouldIgnore($file);
+          })->each(function ($file) use ($dest, $config) {
+              $this->buildFile($file, $dest, $config);
+          });
+
+        }
     }
 
     private function cleanup()

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -62,17 +62,13 @@ class Jigsaw
         // Make a new collection
         $collection = new Collection($files);
 
-        // Filter the collection for ignored resources (ie directories, files, sensitivities)
-        foreach($files as $file){
-          
-          // Use collection class methods to filter the files
-          $collection->filter(function ($file) {
-              return ! $this->shouldIgnore($file);
-          })->each(function ($file) use ($dest, $config) {
-              $this->buildFile($file, $dest, $config);
-          });
+        // Use collection class methods to filter the files
+        $collection->filter(function ($file) {
+            return ! $this->shouldIgnore($file);
+        })->each(function ($file) use ($dest, $config) {
+            $this->buildFile($file, $dest, $config);
+        });
 
-        }
     }
 
     private function cleanup()

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -1,6 +1,6 @@
-<?php namespace Jigsaw\Jigsaw;
+<?php namespace Cambri\Jigsaw;
 
-use Illuminate\Contracts\View\Factory;
+use Illuminate\View\Factory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 

--- a/src/ProcessedFile.php
+++ b/src/ProcessedFile.php
@@ -1,4 +1,4 @@
-<?php namespace Jigsaw\Jigsaw;
+<?php namespace Cambri\Jigsaw;
 
 class ProcessedFile
 {


### PR DESCRIPTION
Substitute for handling collection on build site execution - collection class should likely be injected into the class (L4, L5) or method (L5)  but was creating dependency issues during debugging so it was initiated within the method for further code execution