### PR TITLE
Add BrowserSync to gulpfile

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -6,5 +6,10 @@ elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
     mix.sass('main.scss')
-        .exec('jigsaw build', ['./source/**/*', '!./source/_assets/**/*']);
+        .exec('jigsaw build', ['./source/**/*', '!./source/_assets/**/*'])
+        .browserSync({
+            server: { baseDir: 'build_local' },
+            proxy: null,
+            files: [ 'build_local/**/*' ]
+        });
 });


### PR DESCRIPTION
This adds browsersync to the gulpfile for live reloading and cross device testing.

Has the added side bonus of not really having to worry about writing our own `jigsaw serve` command or anything, `gulp watch` does all of it now.