### PR TITLE
Add basic support for Markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,17 @@
         }
     },
     "require": {
-        "illuminate/container": "~5.0",
-        "illuminate/support": "~5.0",
-        "illuminate/view": "~5.0",
-        "symfony/console": "~2.5",
-        "mockery/mockery": "^0.9.4"
+        "illuminate/container": "^5.2",
+        "illuminate/support": "^5.2",
+        "illuminate/view": "^5.2",
+        "symfony/console": "^2.5",
+        "mockery/mockery": "^0.9.4",
+        "mnapoli/front-yaml": "^1.5"
     },
     "bin": [
         "jigsaw"
-    ]
+    ],
+    "require-dev": {
+        "phpunit/phpunit": "^5.1"
+    }
 }

--- a/jigsaw
+++ b/jigsaw
@@ -13,6 +13,7 @@ use Jigsaw\Jigsaw\Console\InitCommand;
 use Jigsaw\Jigsaw\Filesystem;
 use Jigsaw\Jigsaw\Handlers\BladeHandler;
 use Jigsaw\Jigsaw\Handlers\DefaultHandler;
+use Jigsaw\Jigsaw\Handlers\MarkdownHandler;
 use Jigsaw\Jigsaw\Jigsaw;
 
 if (file_exists(__DIR__.'/vendor/autoload.php')) {
@@ -28,7 +29,7 @@ $sourcePath = getcwd() . '/source';
 
 $container = new Container;
 
-$container->bind(BladeHandler::class, function ($c) use ($cachePath, $sourcePath) {
+$container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     $resolver = new EngineResolver;
 
     $resolver->register('blade', function () use ($cachePath) {
@@ -37,14 +38,20 @@ $container->bind(BladeHandler::class, function ($c) use ($cachePath, $sourcePath
     });
 
     $finder = new FileViewFinder(new Filesystem, [$sourcePath]);
-    $factory = new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
-
-    return new BladeHandler($factory);
+    return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });
 
+$container->bind(BladeHandler::class, function ($c) {
+    return new BladeHandler($c[Factory::class]);
+});
+
+$container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {
+    return new MarkdownHandler($cachePath, $c[Factory::class]);
+});
 
 $jigsaw = new Jigsaw(new Filesystem, $cachePath);
 
+$jigsaw->registerHandler($container[MarkdownHandler::class]);
 $jigsaw->registerHandler($container[BladeHandler::class]);
 $jigsaw->registerHandler($container[DefaultHandler::class]);
 

--- a/jigsaw
+++ b/jigsaw
@@ -15,6 +15,7 @@ use Jigsaw\Jigsaw\Handlers\BladeHandler;
 use Jigsaw\Jigsaw\Handlers\DefaultHandler;
 use Jigsaw\Jigsaw\Handlers\MarkdownHandler;
 use Jigsaw\Jigsaw\Jigsaw;
+use Jigsaw\Jigsaw\TemporaryFilesystem;
 
 if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
@@ -46,7 +47,8 @@ $container->bind(BladeHandler::class, function ($c) {
 });
 
 $container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {
-    return new MarkdownHandler($cachePath, $c[Factory::class]);
+    $tempFilesystem = new TemporaryFilesystem($cachePath);
+    return new MarkdownHandler($tempFilesystem, $c[Factory::class]);
 });
 
 $jigsaw = new Jigsaw(new Filesystem, $cachePath);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -25,11 +25,6 @@ class BladeHandler
 
     public function render($file, $data)
     {
-        return $this->viewFactory->make($this->getViewName($file), $data)->render();
-    }
-
-    private function getViewName($file)
-    {
-        return str_replace('/', '.', $file->getRelativePath()) . '.' . $file->getBasename('.blade.php');
+        return $this->viewFactory->file($file->getRealPath(), $data)->render();
     }
 }

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -46,7 +46,7 @@ class MarkdownHandler
         $yaml = $document->getYAML();
 
         return collect([
-            sprintf("@extends('%s')", $yaml['layout']),
+            sprintf("@extends('%s')", $yaml['extends']),
             sprintf("@section('%s')", $yaml['section']),
             $document->getContent(),
             '@endsection',

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -1,0 +1,58 @@
+<?php namespace Jigsaw\Jigsaw\Handlers;
+
+use Illuminate\Contracts\View\Factory;
+use Jigsaw\Jigsaw\ProcessedFile;
+use Mni\FrontYAML\Parser;
+
+class MarkdownHandler
+{
+    private $tempPath;
+    private $viewFactory;
+    private $parser;
+
+    public function __construct($tempPath, Factory $viewFactory, $parser = null)
+    {
+        $this->tempPath = $tempPath;
+        $this->viewFactory = $viewFactory;
+        $this->parser = $parser ?: new Parser;
+    }
+
+    public function canHandle($file)
+    {
+        return in_array($file->getExtension(), ['markdown', 'md']);
+    }
+
+    public function handle($file, $data)
+    {
+        $filename = $file->getBasename($this->getFileExtension($file)) . '.html';
+        return new ProcessedFile($filename, $file->getRelativePath(), $this->render($file, $data));
+    }
+
+    private function getFileExtension($file)
+    {
+        return '.' . $file->getExtension();
+    }
+
+    public function render($file, $data)
+    {
+        $str = $file->getContents();
+        $document = $this->parser->parse($str);
+        $yaml = $document->getYAML();
+
+        $bladeContents = collect([
+            sprintf("@extends('%s')", $yaml['layout']),
+            sprintf("@section('%s')", $yaml['section']),
+            $document->getContent(),
+            '@endsection',
+        ])->implode("\n");
+
+        $path = $this->tempPath . '/' . sha1($file->getRealPath()) . '.blade.php';
+        file_put_contents($path, $bladeContents);
+
+        $renderedContents = $this->viewFactory->file($path, $data)->render();
+
+        unlink($path);
+
+        return $renderedContents;
+    }
+}

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -35,20 +35,30 @@ class MarkdownHandler
 
     public function render($file, $data)
     {
-        return $this->temporaryFilesystem->put($this->compileToBlade($file), function ($path) use ($data) {
+        list($frontmatter, $content) = $this->parseFile($file);
+
+        $bladeContent = $this->compileToBlade($frontmatter, $content);
+
+        $data = array_merge($data, $frontmatter);
+
+        return $this->temporaryFilesystem->put($bladeContent, function ($path) use ($data) {
             return $this->viewFactory->file($path, $data)->render();
         }, '.blade.php');
     }
 
-    private function compileToBlade($file)
+    private function parseFile($file)
     {
         $document = $this->parser->parse($file->getContents());
-        $yaml = $document->getYAML();
 
+        return [$document->getYAML(), $document->getContent()];
+    }
+
+    private function compileToBlade($frontmatter, $content)
+    {
         return collect([
-            sprintf("@extends('%s')", $yaml['extends']),
-            sprintf("@section('%s')", $yaml['section']),
-            $document->getContent(),
+            sprintf("@extends('%s')", $frontmatter['extends']),
+            sprintf("@section('%s')", $frontmatter['section']),
+            $content,
             '@endsection',
         ])->implode("\n");
     }

--- a/src/TemporaryFilesystem.php
+++ b/src/TemporaryFilesystem.php
@@ -1,0 +1,25 @@
+<?php namespace Jigsaw\Jigsaw;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class TemporaryFilesystem
+{
+    private $tempPath;
+    private $filesystem;
+
+    public function __construct($tempPath, $filesystem = null)
+    {
+        $this->tempPath = $tempPath;
+        $this->filesystem = $filesystem ?: new Filesystem;
+    }
+
+    public function put($contents, $callback, $extension = '')
+    {
+        $path = $this->tempPath . '/' . Str::quickRandom(32) . $extension;
+        $this->filesystem->put($path, $contents);
+        $result = $callback($path);
+        $this->filesystem->delete($path);
+        return $result;
+    }
+}

--- a/src/TemporaryFilesystem.php
+++ b/src/TemporaryFilesystem.php
@@ -1,6 +1,5 @@
 <?php namespace Jigsaw\Jigsaw;
 
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 class TemporaryFilesystem


### PR DESCRIPTION
Allows you to create files  with `.markdown` or `.md` extensions that will be compiled to HTML.

Specifying which layout to use and the layout section is done through YAML front matter. For example, you might have a layout like this:

```html
<html>
    <head>...</head>
    <body>
        @yield('body')
    </body>
</html>
```

If that layout was named `master` in the `_layouts` folder, you could create a Markdown template that used this layout like so:

```markdown
---
extends: _layouts.master
section: body
---

# My awesome heading!

My awesome content!
```

There is also support for custom front matter variables, so given a template like:

```html
<html>
    <head>...</head>
    <body>
        @yield('body')

        @if (isset($footer))
            <footer>{{ $footer }}</footer>
        @endif
    </body>
</html>
```

...and a Markdown file like this:


```markdown
---
extends: _layouts.master
section: body
footer: 'My custom footer content'
---

# My awesome heading!

My awesome content!
```

...you'd get this output:

```html
<html>
    <head>...</head>
    <body>
        <h1>My awesome heading!</h1>

        <p>My awesome content!</p>

        <footer>My custom footer content</footer>
    </body>
</html>
```

## Questions

1. Right now this only support replacing a single section in a Blade template, so you couldn't have a Markdown file with two chunks of content that are meant to be `yield`ed in two different parts of the parent template.

    I don't know if this actually matters at all, no other static site generator I've ever seen supports this either, but I'm curious what people think. The main reason this is important is because the current approach of using front matter is not forwards compatible with supporting multiple sections. We'd have to use `@section` and `@endsection` directly in the Markdown and parse it out ourselves.

2. Right now all variables share the same namespace/scope. So any variables defined in the root `config.php` can potentially collide with variables set in the YAML, and `extends` and `section` become reserved variable names because they are used to tell the Markdown handler what Blade template and section should be used.

    I don't know what I really think here. On one hand, from a purist perspective it would be better to keep everything separately scoped, but on the other hand, trying to do that would likely make it gross to work with. Instead of just being able to do `{{ $myPageVariable }}` you'd have to start doing things like `{{ $pageVariables['myPageVariable'] }}` and `{{ $config['myConfigVariable'] }}.

    It's not totally horrible on it's own but it's one of many small aesthetic decisions that could eventually pile up and muddy things up.