### PR TITLE
Inject markdown content as variable instead of rendering flat into Blade template, resolves #21

### DIFF
--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -37,9 +37,11 @@ class MarkdownHandler
     {
         $document = $this->parseFile($file);
 
-        $bladeContent = $this->compileToBlade($document);
+        $data = array_merge($data, $document->getYAML(), [
+            '__jigsawMarkdownContent' => $document->getContent()
+        ]);
 
-        $data = array_merge($data, $document->getYAML());
+        $bladeContent = $this->compileToBlade($document->getYAML()['extends'], $document->getYAML()['section']);
 
         return $this->temporaryFilesystem->put($bladeContent, function ($path) use ($data) {
             return $this->viewFactory->file($path, $data)->render();
@@ -51,14 +53,12 @@ class MarkdownHandler
         return $this->parser->parse($file->getContents());
     }
 
-    private function compileToBlade($document)
+    private function compileToBlade($extends, $section)
     {
-        $frontmatter = $document->getYAML();
-
         return collect([
-            sprintf("@extends('%s')", $frontmatter['extends']),
-            sprintf("@section('%s')", $frontmatter['section']),
-            $document->getContent(),
+            sprintf("@extends('%s')", $extends),
+            sprintf("@section('%s')", $section),
+            '{!! $__jigsawMarkdownContent !!}',
             '@endsection',
         ])->implode("\n");
     }


### PR DESCRIPTION
This resolves #21 by injecting the Markdown content as a variable to be echo'd by the template, rather than compiling it flat into the template as we were before.