### PR TITLE
Run jigsaw build on changed root files

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -6,7 +6,7 @@ elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
     mix.sass('main.scss')
-        .exec('jigsaw build', ['./source/**/*', '!./source/_assets/**/*'])
+        .exec('jigsaw build', ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
             server: { baseDir: 'build_local' },
             proxy: null,


### PR DESCRIPTION
`jigsaw build` wasn't run when files in the root of the source directory were being changed. This adjustment also makes the `exec` command watch for changes to the root files.