### PR TITLE
Update symfony/console dependency to use "^2.5|^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/container": "^5.2",
         "illuminate/support": "^5.2",
         "illuminate/view": "^5.2",
-        "symfony/console": "^2.5",
+        "symfony/console": "^2.5|^3.0",
         "mockery/mockery": "^0.9.4",
         "mnapoli/front-yaml": "^1.5"
     },


### PR DESCRIPTION
Fixes #29 