### PR TITLE
Add optional --env or -e parameter to gulp watch

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -1,15 +1,18 @@
 var gulp = require('gulp');
 var elixir = require('laravel-elixir');
+var argv = require('yargs').argv;
 
 elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
+    var env = argv.e || argv.env || 'local';
+
     mix.sass('main.scss')
-        .exec('jigsaw build', ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec('jigsaw build --env=' + env, ['./source/**/*', '!./source/_assets/**/*'])
         .browserSync({
-            server: { baseDir: 'build_local' },
+            server: { baseDir: 'build_' + env },
             proxy: null,
-            files: [ 'build_local/**/*' ]
+            files: [ 'build_' + env + '/**/*' ]
         });
 });

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
     "gulp": "^3.8.8"
   },
   "dependencies": {
-    "laravel-elixir": "^4.2.0"
+    "laravel-elixir": "^4.2.0",
+    "yargs": "^4.6.0"
   }
 }


### PR DESCRIPTION
This will trigger the `jigsaw build` with the correct environment variable and also the browserSync to serve from the correct source dir.