### PR TITLE
Change env in build command from option to argument

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,9 +170,9 @@ To create an environment-specific config file, just stick your environment name 
 
 `config.production.php`
 
-To build your site for a specific environment, use the `--env` option:
+To build your site for a specific environment, pass the environment name as the first option:
 
-`$ jigsaw build --env=production`
+`$ jigsaw build production`
 
 Each environment gets it's own `build_*` folder, so in this case your site will be placed in `build_production`.
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1,6 +1,7 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
 use TightenCo\Jigsaw\Jigsaw;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,14 +24,16 @@ class BuildCommand extends Command
     {
         $this->setName('build')
             ->setDescription('Build your site.')
-            ->addOption('env', null, InputOption::VALUE_REQUIRED, "What environment should we use to build?", 'local')
+            ->addArgument('env', InputArgument::OPTIONAL, "What environment should we use to build?", 'local')
             ->addOption('pretty', null, InputOption::VALUE_REQUIRED, "Should the site use pretty URLs?", 'true');
     }
 
     protected function fire()
     {
+        $env = $this->input->getArgument('env');
+
         $config = $this->loadConfig();
-        $this->buildPath .= '_' . $this->input->getOption('env');
+        $this->buildPath .= '_' . $env;
 
         if ($this->input->getOption('pretty') === 'false') {
             $this->jigsaw->setOption('pretty', false);
@@ -42,7 +45,7 @@ class BuildCommand extends Command
 
     private function loadConfig()
     {
-        $env = $this->input->getOption('env');
+        $env = $this->input->getArgument('env');
 
         if ($env !== null && file_exists(getcwd() . "/config.{$env}.php")) {
             $environmentConfig = include getcwd() . "/config.{$env}.php";


### PR DESCRIPTION
Hello, 
This changes build commands environment from an option to an argument. 
`$ jigsaw build --env=production ` would not be `$ jigsaw build production`. 
This is consistent with the serve command as discussed in PR#31.

Thanks