### PR TITLE
Allow Browsersync to build all sites not just the local one.

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -1,15 +1,18 @@
 var gulp = require('gulp');
 var elixir = require('laravel-elixir');
+var gutils = require('gulp-util');
 
 elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
 
+var $environment = gutils.env.env || 'local';
+
 elixir(function(mix) {
     mix.sass('main.scss')
-        .exec('jigsaw build', ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec('jigsaw build --env=' + $environment, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
-            server: { baseDir: 'build_local' },
+            server: { baseDir: 'build_' + $environment },
             proxy: null,
-            files: [ 'build_local/**/*' ]
+            files: [ 'build_' + $environment + '/**/*' ]
         });
 });

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "devDependencies": {
-    "gulp": "^3.8.8"
+    "gulp": "^3.8.8",
+    "gulp-util": "^3.0.7"
   },
   "dependencies": {
     "laravel-elixir": "^4.2.0"


### PR DESCRIPTION
As requested I'm re-opening this pull request.

This is a simple change to the Gulp/BrowserSync configuration to facilitate building of all jigsaw sites not just the local one.

### Rationale
There may be circumstances where a user wants to work on any one of the variants of a Jigsaw site during development. For example;

- Configuration in `config.<site>.php ` can effect how the site operates. The local site might use placeholder content but the production site uses ajax to pull in content.
- A Jigsaw site might be a template with `config.client-site-1.php` and `config.client-site-2.php` etc.  determing what content to pull in allowing one Jigsaw site to be reused for multiple paying clients (this is my use case).
- Maybe there are different localisations in `config.en_GB.php ` and `config.en_US.php `.

To summarise, the developers workflow might be more complex than simple parameter changes between development and production sites. Actively developing on a chosen site may be more pragmatic in some use cases.

### Workflow changes
- Running `gulp watch --env=foo` will result in gulp executing `jigsaw build --env=foo` upon file changes.
- Running `gulp watch` will result in gulp executing `gulp watch --env=local` upon file changes.