### PR TITLE
Update gulpfile.js

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -6,10 +6,10 @@ elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
-    var env = argv.e || argv.env || 'local';
+    var env = argv.e || 'local';
 
     mix.sass('main.scss')
-        .exec('jigsaw build --env=' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec('jigsaw build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
             server: { baseDir: 'build_' + env },
             proxy: null,

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -6,7 +6,7 @@ elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
-    var env = argv.e || 'local';
+    var env = argv.e || argv.env || 'local';
 
     mix.sass('main.scss')
         .exec('jigsaw build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])


### PR DESCRIPTION
Remove --env option handling since it is now an argument. Having that in the gulp file caused jigsaw build to fail with "The --env option does not exist."