### PR TITLE
Allow Browser Sync port to be specified from command line

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -7,10 +7,12 @@ elixir.config.publicPath = 'source';
 
 elixir(function(mix) {
     var env = argv.e || argv.env || 'local';
+    var port = argv.p || argv.port || 3000;
 
     mix.sass('main.scss')
         .exec('jigsaw build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
+            port: port,
             server: { baseDir: 'build_' + env },
             proxy: null,
             files: [ 'build_' + env + '/**/*' ]


### PR DESCRIPTION
Defaults to the default Browser Sync port: 3000.