### PR TITLE
Adding the $hidden parameter to the allFiles() method to squelch PHP …

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -5,7 +5,7 @@ use Symfony\Component\Finder\Finder;
 
 class Filesystem extends BaseFilesystem
 {
-    public function allFiles($directory)
+    public function allFiles($directory, $hidden = false)
     {
         return iterator_to_array(Finder::create()->ignoreDotFiles(false)->files()->in($directory), false);
     }


### PR DESCRIPTION
…warnings:

 * PHP Warning:  Declaration of TightenCo\Jigsaw\Filesystem::allFiles($directory) should be compatible with Illuminate\Filesystem\Filesystem::allFiles($directory, $hidden = false) in /Users/joshuablake/.composer/vendor/tightenco/jigsaw/src/Filesystem.php on line 6

 * Warning: Declaration of TightenCo\Jigsaw\Filesystem::allFiles($directory) should be compatible with Illuminate\Filesystem\Filesystem::allFiles($directory, $hidden = false) in /Users/joshuablake/.composer/vendor/tightenco/jigsaw/src/Filesystem.php on line 6