### PR TITLE
Add Elixir versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "autoload": {
         "psr-4": {
             "TightenCo\\Jigsaw\\": "src"
-        }
+        },
+        "files": [
+            "src/Support/helpers.php"
+        ]
     },
     "require": {
         "illuminate/container": "^5.2",

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -35,7 +35,11 @@ if (! function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            return $buildDirectory.'/'.$manifest[$file];
+            if ($buildDirectory === '') {
+                return '/'.$manifest[$file];
+            }
+
+            return '/'.$buildDirectory.'/'.$manifest[$file];
         }
 
         return $file;

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,0 +1,45 @@
+<?php
+
+if (! function_exists('public_path')) {
+    /**
+     * Get the path to the public folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function public_path($path = '')
+    {
+        return 'source'.($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+}
+
+if (! function_exists('elixir')) {
+    /**
+     * Get the path to a versioned Elixir file.
+     *
+     * @param  string  $file
+     * @param  string  $buildDirectory
+     * @return string
+     *
+     * @throws \InvalidArgumentException
+     */
+    function elixir($file, $buildDirectory = 'build')
+    {
+        static $manifest;
+        static $manifestPath;
+
+        if (is_null($manifest) || $manifestPath !== $buildDirectory) {
+            $manifest = json_decode(file_get_contents(public_path($buildDirectory.'/rev-manifest.json')), true);
+
+            $manifestPath = $buildDirectory;
+        }
+
+        if (isset($manifest[$file])) {
+            return $buildDirectory.'/'.$manifest[$file];
+        }
+
+        return $file;
+
+        throw new InvalidArgumentException("File {$file} not defined in asset manifest.");
+    }
+}

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -35,11 +35,7 @@ if (! function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            if ($buildDirectory === '') {
-                return '/'.$manifest[$file];
-            }
-
-            return '/'.$buildDirectory.'/'.$manifest[$file];
+            return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
         }
 
         return $file;


### PR DESCRIPTION
Hey Adam,

As mentioned in #51 I was able to set up versioning for jigsaw so it works the same as it does in Laravel.

I included `src/Support/helpers.php` which contains `public_path()` and `elixir()`. `public_path()` makes sure that it uses the `rev-manifest.json` within the source folder. And I included it all in the files section of `composer.json` for autoloading.

I also noticed that it included a duplicate slash if an empty build path was used (which is necessary when using relative paths to fonts or images from css), so I included a check to handle that.