### PR TITLE
Additional collections features

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -75,7 +75,7 @@ $container->bind(ViewRenderer::class, function ($c) {
 });
 
 $container->bind(BladeHandler::class, function ($c) {
-    return new BladeHandler($c[ViewRenderer::class]);
+    return new BladeHandler($c[TemporaryFilesystem::class], $c[ViewRenderer::class]);
 });
 
 $container->bind(TemporaryFilesystem::class, function ($c) use ($cachePath) {

--- a/jigsaw
+++ b/jigsaw
@@ -87,7 +87,7 @@ $container->bind(MarkdownHandler::class, function ($c) {
 });
 
 $container->bind(CollectionPathResolver::class, function ($c ) {
-    return new CollectionPathResolver($c['outputPathResolver']);
+    return new CollectionPathResolver($c['outputPathResolver'], $c[ViewRenderer::class]);
 });
 
 $container->bind(CollectionDataLoader::class, function ($c) {

--- a/jigsaw
+++ b/jigsaw
@@ -90,7 +90,7 @@ $container->bind(DataLoader::class, function ($c) {
 });
 
 $container->bind(CollectionItemHandler::class, function ($c) {
-    return new CollectionItemHandler($c['collectionSettings'], $c['outputPathResolver'], [$c[MarkdownHandler::class]]);
+    return new CollectionItemHandler($c['collectionSettings'], [$c[MarkdownHandler::class]]);
 });
 
 $container->bind(CollectionPaginator::class, function ($c) {

--- a/jigsaw
+++ b/jigsaw
@@ -12,6 +12,7 @@ use TightenCo\Jigsaw\BasicOutputPathResolver;
 use TightenCo\Jigsaw\CollectionDataLoader;
 use TightenCo\Jigsaw\CollectionHandlers\MarkdownCollectionItemHandler;
 use TightenCo\Jigsaw\CollectionPaginator;
+use TightenCo\Jigsaw\CollectionPathResolver;
 use TightenCo\Jigsaw\Console\BuildCommand;
 use TightenCo\Jigsaw\Console\InitCommand;
 use TightenCo\Jigsaw\Console\ServeCommand;
@@ -56,6 +57,7 @@ $container->instance('collectionSettings', $collectionSettings);
 $container->bind('outputPathResolver', function ($c ) {
     return new BasicOutputPathResolver;
 });
+
 $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     $resolver = new EngineResolver;
 
@@ -84,8 +86,12 @@ $container->bind(MarkdownHandler::class, function ($c) {
     return new MarkdownHandler($c[TemporaryFilesystem::class], $c[FrontMatterParser::class], $c[ViewRenderer::class]);
 });
 
+$container->bind(CollectionPathResolver::class, function ($c ) {
+    return new CollectionPathResolver($c['outputPathResolver']);
+});
+
 $container->bind(CollectionDataLoader::class, function ($c) {
-    return new CollectionDataLoader($c['collectionSettings'], new Filesystem, $c['outputPathResolver'], [
+    return new CollectionDataLoader($c['collectionSettings'], new Filesystem, $c[CollectionPathResolver::class], [
         $c[MarkdownCollectionItemHandler::class],
     ]);
 });

--- a/jigsaw
+++ b/jigsaw
@@ -42,7 +42,19 @@ $sourcePath = getcwd() . '/source';
 $container = new Container;
 $config = include getcwd() . '/config.php';
 
+if (! file_exists(getcwd() . '/collections.php')) {
+    $collectionSettings = [];
+} else {
+    $collectionSettings = include getcwd() . '/collections.php';
+}
+
+$container->instance('cwd', getcwd());
 $container->instance('config', $config);
+$container->instance('collectionSettings', $collectionSettings);
+
+$container->bind('outputPathResolver', function ($c ) {
+    return new BasicOutputPathResolver;
+});
 $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     $resolver = new EngineResolver;
 
@@ -64,24 +76,13 @@ $container->bind(TemporaryFilesystem::class, function ($c) use ($cachePath) {
 });
 
 $container->bind(MarkdownHandler::class, function ($c) {
-    return new MarkdownHandler($c[TemporaryFilesystem::class], $c[Factory::class]);
-});
-
-if (! file_exists(getcwd() . '/collections.php')) {
-    $collectionSettings = [];
-} else {
-    $collectionSettings = include getcwd() . '/collections.php';
-}
-
-$container->instance('cwd', getcwd());
-$container->instance('collectionSettings', $collectionSettings);
-
-$container->bind('outputPathResolver', function ($c ) {
-    return new BasicOutputPathResolver;
+    return new MarkdownHandler($c[TemporaryFilesystem::class], $c[Factory::class], $c[FrontMatterParser::class]);
 });
 
 $container->bind(CollectionDataLoader::class, function ($c) {
-    return new CollectionDataLoader($c['collectionSettings'], new Filesystem, $c['outputPathResolver'], [new MarkdownCollectionItemHandler]);
+    return new CollectionDataLoader($c['collectionSettings'], new Filesystem, $c['outputPathResolver'], [
+        $c[MarkdownCollectionItemHandler::class],
+    ]);
 });
 
 $container->bind(DataLoader::class, function ($c) {
@@ -102,7 +103,6 @@ $container->bind(PaginatedPageHandler::class, function ($c) {
 
 $container->bind(SiteBuilder::class, function ($c) use ($cachePath) {
     return new SiteBuilder(new Filesystem, $cachePath, $c['outputPathResolver'], [
-        // @todo: Write and stick a pagination handler at the top of this stack
         $c[PaginatedPageHandler::class],
         $c[CollectionItemHandler::class],
         new IgnoredHandler,

--- a/jigsaw
+++ b/jigsaw
@@ -6,9 +6,11 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
+use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
 use TightenCo\Jigsaw\BasicOutputPathResolver;
+use TightenCo\Jigsaw\BladeMarkdownEngine;
 use TightenCo\Jigsaw\CollectionDataLoader;
 use TightenCo\Jigsaw\CollectionHandlers\MarkdownCollectionItemHandler;
 use TightenCo\Jigsaw\CollectionPaginator;
@@ -26,6 +28,7 @@ use TightenCo\Jigsaw\Handlers\IgnoredHandler;
 use TightenCo\Jigsaw\Handlers\MarkdownHandler;
 use TightenCo\Jigsaw\Handlers\PaginatedPageHandler;
 use TightenCo\Jigsaw\Jigsaw;
+use TightenCo\Jigsaw\MarkdownEngine;
 use TightenCo\Jigsaw\SiteBuilder;
 use TightenCo\Jigsaw\TemporaryFilesystem;
 use TightenCo\Jigsaw\ViewRenderer;
@@ -54,19 +57,34 @@ $container->instance('cwd', getcwd());
 $container->instance('config', $config);
 $container->instance('collectionSettings', $collectionSettings);
 
-$container->bind('outputPathResolver', function ($c ) {
+$container->bind('outputPathResolver', function ($c) {
     return new BasicOutputPathResolver;
 });
 
 $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     $resolver = new EngineResolver;
 
-    $resolver->register('blade', function () use ($cachePath) {
-        $compiler = new BladeCompiler(new Filesystem, $cachePath);
-        return new CompilerEngine($compiler, new Filesystem);
+    $bladeCompiler = new BladeCompiler(new Filesystem, $cachePath);
+    $compilerEngine = new CompilerEngine($bladeCompiler, new Filesystem);
+
+    $resolver->register('blade', function () use ($compilerEngine) {
+        return $compilerEngine;
+    });
+
+    $resolver->register('php', function () {
+        return new PhpEngine();
+    });
+
+    $resolver->register('markdown', function () use ($c, $sourcePath) {
+        return new MarkdownEngine($c[FrontMatterParser::class], new Filesystem, $sourcePath);
+    });
+
+    $resolver->register('blade-markdown', function () use ($c, $compilerEngine) {
+        return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
 
     $finder = new FileViewFinder(new Filesystem, [$sourcePath]);
+
     return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });
 

--- a/jigsaw
+++ b/jigsaw
@@ -1,32 +1,33 @@
 #!/usr/bin/env php
 <?php
 
-use Illuminate\View\Factory;
-use TightenCo\Jigsaw\Jigsaw;
-use TightenCo\Jigsaw\DataLoader;
-use TightenCo\Jigsaw\Filesystem;
-use TightenCo\Jigsaw\SiteBuilder;
 use Illuminate\Container\Container;
-use Illuminate\View\FileViewFinder;
-use TightenCo\Jigsaw\FrontMatterParser;
-use TightenCo\Jigsaw\CollectionPaginator;
-use TightenCo\Jigsaw\Console\InitCommand;
-use TightenCo\Jigsaw\TemporaryFilesystem;
-use TightenCo\Jigsaw\CollectionDataLoader;
-use TightenCo\Jigsaw\Console\BuildCommand;
-use TightenCo\Jigsaw\Console\ServeCommand;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
-use TightenCo\Jigsaw\Handlers\BladeHandler;
-use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Factory;
+use Illuminate\View\FileViewFinder;
 use TightenCo\Jigsaw\BasicOutputPathResolver;
+use TightenCo\Jigsaw\CollectionDataLoader;
+use TightenCo\Jigsaw\CollectionHandlers\MarkdownCollectionItemHandler;
+use TightenCo\Jigsaw\CollectionPaginator;
+use TightenCo\Jigsaw\Console\BuildCommand;
+use TightenCo\Jigsaw\Console\InitCommand;
+use TightenCo\Jigsaw\Console\ServeCommand;
+use TightenCo\Jigsaw\DataLoader;
+use TightenCo\Jigsaw\Filesystem;
+use TightenCo\Jigsaw\FrontMatterParser;
+use TightenCo\Jigsaw\Handlers\BladeHandler;
+use TightenCo\Jigsaw\Handlers\CollectionItemHandler;
 use TightenCo\Jigsaw\Handlers\DefaultHandler;
 use TightenCo\Jigsaw\Handlers\IgnoredHandler;
 use TightenCo\Jigsaw\Handlers\MarkdownHandler;
 use TightenCo\Jigsaw\Handlers\PaginatedPageHandler;
-use TightenCo\Jigsaw\Handlers\CollectionItemHandler;
-use TightenCo\Jigsaw\CollectionHandlers\MarkdownCollectionItemHandler;
+use TightenCo\Jigsaw\Jigsaw;
+use TightenCo\Jigsaw\SiteBuilder;
+use TightenCo\Jigsaw\TemporaryFilesystem;
+use TightenCo\Jigsaw\ViewRenderer;
 
 if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
@@ -67,8 +68,12 @@ $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });
 
+$container->bind(ViewRenderer::class, function ($c) {
+    return new ViewRenderer($c[Factory::class]);
+});
+
 $container->bind(BladeHandler::class, function ($c) {
-    return new BladeHandler($c[Factory::class]);
+    return new BladeHandler($c[ViewRenderer::class]);
 });
 
 $container->bind(TemporaryFilesystem::class, function ($c) use ($cachePath) {
@@ -76,7 +81,7 @@ $container->bind(TemporaryFilesystem::class, function ($c) use ($cachePath) {
 });
 
 $container->bind(MarkdownHandler::class, function ($c) {
-    return new MarkdownHandler($c[TemporaryFilesystem::class], $c[Factory::class], $c[FrontMatterParser::class]);
+    return new MarkdownHandler($c[TemporaryFilesystem::class], $c[FrontMatterParser::class], $c[ViewRenderer::class]);
 });
 
 $container->bind(CollectionDataLoader::class, function ($c) {
@@ -98,7 +103,7 @@ $container->bind(CollectionPaginator::class, function ($c) {
 });
 
 $container->bind(PaginatedPageHandler::class, function ($c) {
-    return new PaginatedPageHandler($c[CollectionPaginator::class], $c[Factory::class], $c[FrontMatterParser::class], $c[TemporaryFilesystem::class]);
+    return new PaginatedPageHandler($c[CollectionPaginator::class], $c[FrontMatterParser::class], $c[TemporaryFilesystem::class], $c[ViewRenderer::class]);
 });
 
 $container->bind(SiteBuilder::class, function ($c) use ($cachePath) {

--- a/jigsaw
+++ b/jigsaw
@@ -40,7 +40,9 @@ $buildPath = getcwd() . '/build';
 $sourcePath = getcwd() . '/source';
 
 $container = new Container;
+$config = include getcwd() . '/config.php';
 
+$container->instance('config', $config);
 $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     $resolver = new EngineResolver;
 
@@ -83,7 +85,7 @@ $container->bind(CollectionDataLoader::class, function ($c) {
 });
 
 $container->bind(DataLoader::class, function ($c) {
-    return new DataLoader($c['cwd'], $c[CollectionDataLoader::class]);
+    return new DataLoader($c['config'], $c['cwd'], $c[CollectionDataLoader::class]);
 });
 
 $container->bind(CollectionItemHandler::class, function ($c) {

--- a/src/BasicOutputPathResolver.php
+++ b/src/BasicOutputPathResolver.php
@@ -4,10 +4,12 @@ class BasicOutputPathResolver
 {
     public function link($path, $name, $type, $page = 1)
     {
-        if ($page > 1) {
-            return $this->clean('/' . $path . '/' . $page . '/' . $name . '.' . $type);
-        }
-        return $this->clean('/' . $path . '/' . $name . '.' . $type);
+        $extension = $type ? '.' . $type : '';
+        $name = basename($name, $extension);
+
+        return $page > 1 ?
+            $this->clean('/' . $path . '/' . $page . '/' . $name . $extension) :
+            $this->clean('/' . $path . '/' . $name . $extension);
     }
 
     public function path($path, $name, $type, $page = 1)
@@ -17,10 +19,9 @@ class BasicOutputPathResolver
 
     public function directory($path, $name, $type, $page = 1)
     {
-        if ($page > 1) {
-            return $this->clean($path . '/' . $page);
-        }
-        return $this->clean($path);
+        return $page > 1 ?
+            $this->clean($path . '/' . $page) :
+            $this->clean($path);
     }
 
     private function clean($path)

--- a/src/BladeMarkdownEngine.php
+++ b/src/BladeMarkdownEngine.php
@@ -1,0 +1,53 @@
+<?php namespace TightenCo\Jigsaw;
+
+use Exception;
+use Illuminate\View\Engines\EngineInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Throwable;
+use TightenCo\Jigsaw\Filesystem;
+
+class BladeMarkdownEngine implements EngineInterface
+{
+    private $blade;
+    private $markdown;
+
+    public function __construct($compilerEngine, $markdown)
+    {
+        $this->blade = $compilerEngine;
+        $this->markdown = $markdown;
+    }
+
+    public function get($path, array $data = [])
+    {
+        $content = $this->evaluateBlade($path, $data);
+
+        return $this->evaluateMarkdown($content);
+    }
+
+    protected function evaluateBlade($path, $data)
+    {
+        try {
+            return $this->blade->get($path, $data);
+        } catch (Exception $e) {
+            $this->handleViewException($e);
+        } catch (Throwable $e) {
+            $this->handleViewException(new FatalThrowableError($e));
+        }
+    }
+
+    protected function evaluateMarkdown($content)
+    {
+        try {
+            return $this->markdown->parseMarkdown($content)->content;
+        } catch (Exception $e) {
+            $this->handleViewException($e);
+        } catch (Throwable $e) {
+            $this->handleViewException(new FatalThrowableError($e));
+        }
+    }
+
+    protected function handleViewException(Exception $e)
+    {
+        throw $e;
+    }
+}

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -67,10 +67,24 @@ class Collection extends BaseCollection
     private function sortItems($items, $sortSetting)
     {
         $sortKey = ltrim($sortSetting, '-+');
-        $sortFunction = $sortSetting[0] === '-' ? 'sortByDesc' : 'sortBy';
+        $sortType = $sortSetting[0] === '-' ? 'sortByDesc' : 'sortBy';
+        $sortKeyFunction = $this->checkIfSortKeyIsFunction($sortKey);
 
-        return $items->{$sortFunction}(function ($item, $_) use ($sortKey) {
-            return $item->{$sortKey};
+        return $items->{$sortType}(function ($item, $_) use ($sortKey, $sortKeyFunction) {
+            return $sortKeyFunction ?
+                call_user_func_array([$item, $sortKeyFunction[0]], $sortKeyFunction[1]) :
+                $item->$sortKey;
         });
+    }
+
+    private function checkIfSortKeyIsFunction($sortKey)
+    {
+        $sortKeyFunction = explode('(', str_replace(' ', '', $sortKey), 2);
+
+        if (isset($sortKeyFunction[1])) {
+            $parameterss = explode(',', trim($sortKeyFunction[1], ')'));
+
+            return [$sortKeyFunction[0], $parameterss];
+        }
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -21,7 +21,7 @@ class Collection extends BaseCollection
         $sortedItems = $this->defaultSort($items)->keyBy(function($item) {
             return $item->filename;
         });
-        parent::__construct($this->addAdjacentItems($sortedItems));
+        $this->items = $this->getArrayableItems($this->addAdjacentItems($sortedItems));
 
         return $this;
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -18,13 +18,26 @@ class Collection extends BaseCollection
 
     public function loadItems($items)
     {
-        parent::__construct(
-            $this->defaultSort($items->keyBy(function($item) {
-                return $item->filename;
-            }))
-        );
+        $sortedItems = $this->defaultSort($items)->keyBy(function($item) {
+            return $item->filename;
+        });
+        parent::__construct($this->addAdjacentItems($sortedItems));
 
         return $this;
+    }
+
+    public function addAdjacentItems($items)
+    {
+        $count = $items->count();
+        $adjacentItems = $items->map(function($item) {
+            return $item->filename;
+        });
+        $previousItems = $adjacentItems->prepend(null)->take($count);
+        $nextItems = $adjacentItems->push(null)->take(-$count);
+
+        return $items->map(function($item) use ($previousItems, $nextItems) {
+            return $item->put('_previousItem', $previousItems->shift())->put('_nextItem', $nextItems->shift());
+        });
     }
 
     public function getDefaultVariables()

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,0 +1,65 @@
+<?php namespace TightenCo\Jigsaw;
+
+use Illuminate\Support\Collection as BaseCollection;
+
+class Collection extends BaseCollection
+{
+    private $settings;
+    public $name;
+
+    public static function withSettings($settings, $name)
+    {
+        $collection = new static;
+        $collection->settings = $settings;
+        $collection->name = $name;
+
+        return $collection;
+    }
+
+    public function loadItems($items)
+    {
+        parent::__construct(
+            $this->defaultSort($items->keyBy(function($item) {
+                return $item->filename;
+            }))
+        );
+
+        return $this;
+    }
+
+    public function getDefaultVariables()
+    {
+        return array_get($this->settings, 'variables', []);
+    }
+
+    public function getPermalink()
+    {
+        return array_get($this->settings, 'permalink') ?: function($data) {
+            return slugify($data['filename']);
+        };
+    }
+
+    public function getHelpers()
+    {
+        return array_get($this->settings, 'helpers', []);
+    }
+
+    private function defaultSort($items)
+    {
+        return collect(array_get($this->settings, 'sort'))
+            ->reverse()
+            ->reduce(function ($carry, $sortSetting) {
+                return $this->sortItems($carry, $sortSetting);
+            }, $items);
+    }
+
+    private function sortItems($items, $sortSetting)
+    {
+        $sortKey = ltrim($sortSetting, '-+');
+        $sortFunction = $sortSetting[0] === '-' ? 'sortByDesc' : 'sortBy';
+
+        return $items->{$sortFunction}(function ($item, $_) use ($sortKey) {
+            return $item->{$sortKey};
+        });
+    }
+}

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -47,9 +47,7 @@ class Collection extends BaseCollection
 
     public function getPermalink()
     {
-        return array_get($this->settings, 'path') ?: function($data) {
-            return slugify($data['filename']);
-        };
+        return array_get($this->settings, 'path');
     }
 
     public function getHelpers()

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -47,7 +47,7 @@ class Collection extends BaseCollection
 
     public function getPermalink()
     {
-        return array_get($this->settings, 'permalink') ?: function($data) {
+        return array_get($this->settings, 'path') ?: function($data) {
             return slugify($data['filename']);
         };
     }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -18,9 +18,11 @@ class CollectionDataLoader
     public function load($source)
     {
         return $this->settings->map(function ($collectionSettings, $name) use ($source) {
-            // Merge in any default collection settings
             $collectionSettings = array_merge([
-                'helpers' => []
+                'helpers' => [],
+                'permalink' => function($data) {
+                    return $data['filename'];
+                },
             ], $collectionSettings);
 
             return $this->loadSingleCollectionData($source, $name, $collectionSettings);

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -46,7 +46,8 @@ class CollectionDataLoader
 
         $data = array_merge($collection->getDefaultVariables(), $handler->getData($file), $this->getMeta($file));
 
-        return new CollectionItem(
+        return CollectionItem::build(
+            $collection,
             array_merge($data, ['link' => $this->getPermalink($collection, $data)]),
             $collection->getHelpers()
         );

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -56,6 +56,7 @@ class CollectionDataLoader
     private function getMeta($file)
     {
         $meta['filename'] = $file->getFilenameWithoutExtension();
+        $meta['extension'] = $file->getFullExtension();
 
         return $meta;
     }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -1,6 +1,8 @@
 <?php namespace TightenCo\Jigsaw;
 
 use Exception;
+use TightenCo\Jigsaw\IterableObject;
+use TightenCo\Jigsaw\IterableObjectWithDefault;
 
 class CollectionDataLoader
 {
@@ -60,18 +62,34 @@ class CollectionDataLoader
         $data['filename'] = $file->getFilenameWithoutExtension();
         $data['extension'] = $file->getFullExtension();
         $data['link'] = $this->getPermalink($collection, $data);
-        $data['path'] = trim($data['link'], '/');
-        $data['url'] = rtrim(array_get($this->globalSettings, 'baseUrl'), '/') . '/' . trim($data['link'], '/');
+        $data['path'] = $this->buildPaths($data['link']);
+        $data['url'] = $this->buildUrls($data['path']);
 
         return $data;
     }
 
+    private function buildPaths($links)
+    {
+        $paths = collect($links)->map(function($link) {
+            return trim($link, '/');
+        });
+
+        return $paths->count() ? new IterableObjectWithDefault($paths) : null;
+    }
+
+    private function buildUrls($paths)
+    {
+        $urls = collect($paths)->map(function($path) {
+            return rtrim(array_get($this->globalSettings, 'baseUrl'), '/') . '/' . $path;
+        });
+
+        return $urls->count() ? new IterableObjectWithDefault($urls) : null;
+    }
+
     private function getPermalink($collection, $data)
     {
-        if (! array_get($data, 'extends')) {
-            return;
-        }
+        $link = $this->pathResolver->link($collection->getPermalink(), new IterableObject($data));
 
-        return $this->pathResolver->link($collection->getPermalink(), $data);
+        return $link->count() ? new IterableObjectWithDefault($link) : null;
     }
 }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -40,10 +40,19 @@ class CollectionDataLoader
             return $handler->shouldHandle($file);
         }, function () { throw new Exception('No matching collection item handler'); });
 
-        $data = $handler->getData($file);
+        $data = array_merge(
+            ['filename' => $this->getFilenameWithoutExtension($file)],
+            $handler->getData($file)
+        );
+
         $link = $this->getCollectionItemLink($data, $settings);
 
         return new CollectionItem(array_merge($data, ['link' => $link]), $settings['helpers']);
+    }
+
+    private function getFilenameWithoutExtension($file)
+    {
+        return $file->getBasename('.' . $file->getExtension());
     }
 
     private function getCollectionItemLink($data, $settings)

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -21,7 +21,7 @@ class CollectionDataLoader
             $settings = array_merge([
                 'helpers' => [],
                 'permalink' => function($data) {
-                    return $data['filename'];
+                    return slugify($data['filename']);
                 },
             ], $settings);
             $data = $this->loadSingleCollectionData($source, $collectionName, $settings);
@@ -80,7 +80,7 @@ class CollectionDataLoader
 
     private function getCollectionItemLink($data, $settings)
     {
-        $permalink = slugify($settings['permalink']->__invoke($data));
+        $permalink = $settings['permalink']->__invoke($data);
 
         return $this->outputPathResolver->link(dirname($permalink), basename($permalink), 'html');
     }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -88,8 +88,8 @@ class CollectionDataLoader
 
     private function getPermalink($collection, $data)
     {
-        $link = $this->pathResolver->link($collection->getPermalink(), new IterableObject($data));
+        $links = $this->pathResolver->link($collection->getPermalink(), new IterableObject($data));
 
-        return $link->count() ? new IterableObjectWithDefault($link) : null;
+        return $links->count() ? new IterableObjectWithDefault($links) : null;
     }
 }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -44,9 +44,9 @@ class CollectionDataLoader
 
         $data = array_merge(
             ['filename' => $this->getFilenameWithoutExtension($file)],
+            array_get($settings, 'variables', []),
             $handler->getData($file)
         );
-
         $link = $this->getCollectionItemLink($data, $settings);
 
         return new CollectionItem(array_merge($data, ['link' => $link]), $settings['helpers']);

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -63,6 +63,6 @@ class CollectionDataLoader
     {
         $permalink = $collection->getPermalink()->__invoke($data);
 
-        return $this->outputPathResolver->link(dirname($permalink), basename($permalink), 'html');
+        return rtrim($this->outputPathResolver->link(dirname($permalink), basename($permalink), 'html'), '/');
     }
 }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -48,7 +48,7 @@ class CollectionDataLoader
 
     private function getCollectionItemLink($data, $settings)
     {
-        $permalink = $settings['permalink']->__invoke($data);
+        $permalink = slugify($settings['permalink']->__invoke($data));
 
         return $this->outputPathResolver->link(dirname($permalink), basename($permalink), 'html');
     }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -6,16 +6,16 @@ class CollectionDataLoader
 {
     private $settings;
     private $filesystem;
-    private $outputPathResolver;
+    private $pathResolver;
     private $handlers;
     private $source;
     private $globalSettings;
 
-    public function __construct($settings, $filesystem, $outputPathResolver, $handlers = [])
+    public function __construct($settings, $filesystem, $pathResolver, $handlers = [])
     {
         $this->settings = collect($settings);
         $this->filesystem = $filesystem;
-        $this->outputPathResolver = $outputPathResolver;
+        $this->pathResolver = $pathResolver;
         $this->handlers = collect($handlers);
     }
 
@@ -72,8 +72,6 @@ class CollectionDataLoader
             return;
         }
 
-        $permalink = $collection->getPermalink()->__invoke($data);
-
-        return rtrim($this->outputPathResolver->link(dirname($permalink), basename($permalink), 'html'), '/');
+        return $this->pathResolver->link($collection->getPermalink(), $data);
     }
 }

--- a/src/CollectionDataLoader.php
+++ b/src/CollectionDataLoader.php
@@ -56,6 +56,7 @@ class CollectionDataLoader
 
     private function addMeta($data, $collection, $file)
     {
+        $data['collection'] = $collection->name;
         $data['filename'] = $file->getFilenameWithoutExtension();
         $data['extension'] = $file->getFullExtension();
         $data['link'] = $this->getPermalink($collection, $data);

--- a/src/CollectionHandlers/MarkdownCollectionItemHandler.php
+++ b/src/CollectionHandlers/MarkdownCollectionItemHandler.php
@@ -1,15 +1,14 @@
 <?php namespace TightenCo\Jigsaw\CollectionHandlers;
 
-use Mni\FrontYAML\Parser;
-use TightenCo\Jigsaw\CollectionItem;
+use TightenCo\Jigsaw\FrontMatterParser;
 
 class MarkdownCollectionItemHandler
 {
     private $parser;
 
-    public function __construct($parser = null)
+    public function __construct(FrontMatterParser $parser)
     {
-        $this->parser = $parser ?: new Parser;
+        $this->parser = $parser;
     }
 
     public function shouldHandle($file)
@@ -21,6 +20,6 @@ class MarkdownCollectionItemHandler
     {
         $document = $this->parser->parse($file->getContents());
 
-        return array_merge($document->getYAML(), ['content' => $document->getContent()]);
+        return array_merge(['section' => 'content'], $document->frontMatter, ['content' => $document->content]);
     }
 }

--- a/src/CollectionHandlers/MarkdownCollectionItemHandler.php
+++ b/src/CollectionHandlers/MarkdownCollectionItemHandler.php
@@ -18,7 +18,7 @@ class MarkdownCollectionItemHandler
 
     public function getData($file)
     {
-        $document = $this->parser->parse($file->getContents());
+        $document = $this->parser->parseMarkdown($file->getContents());
 
         return array_merge(['section' => 'content'], $document->frontMatter, ['content' => $document->content]);
     }

--- a/src/CollectionItem.php
+++ b/src/CollectionItem.php
@@ -18,6 +18,6 @@ class CollectionItem
 
     public function __call($method, $args)
     {
-        return $this->helpers[$method]->__invoke($this->data);
+        return $this->helpers[$method]->__invoke($this->data, ...$args);
     }
 }

--- a/src/CollectionItem.php
+++ b/src/CollectionItem.php
@@ -13,7 +13,6 @@ class CollectionItem extends IterableObject
         $item = new static($data);
         $item->collection = $collection;
         $item->helpers = $helpers;
-        $item->put('collection', $collection->name);
 
         return $item;
     }

--- a/src/CollectionItem.php
+++ b/src/CollectionItem.php
@@ -11,6 +11,16 @@ class CollectionItem
         $this->helpers = $helpers;
     }
 
+    public function getFilename()
+    {
+        return $this->data['filename'];
+    }
+
+    public function getLink()
+    {
+        return $this->data['link'];
+    }
+
     public function __get($key)
     {
         return $this->data[$key];

--- a/src/CollectionItem.php
+++ b/src/CollectionItem.php
@@ -13,6 +13,8 @@ class CollectionItem extends IterableObject
         $item = new static($data);
         $item->collection = $collection;
         $item->helpers = $helpers;
+        $item->put('collection', $collection->name);
+
         return $item;
     }
 
@@ -34,8 +36,8 @@ class CollectionItem extends IterableObject
     private function getHelper($name)
     {
         return array_get($this->helpers, $name) ?: function() use ($name) {
-            $collection = $this->collection->name;
-            throw new Exception("No helper function named '$name' in the collection '$collection'.");
+            $collection = $this->get('collection');
+            throw new Exception('No helper function named "' . $name. '" for the collection "' . $this->get('collection') . '" was found in the file "collections.php".');
         };
     }
 }

--- a/src/CollectionPaginator.php
+++ b/src/CollectionPaginator.php
@@ -37,7 +37,7 @@ class CollectionPaginator
     {
         return rtrim($this->outputPathResolver->link(
             $file->getRelativePath(),
-            $file->getBasename('.blade.php'),
+            $file->getFilenameWithoutExtension(),
             'html',
             $pageNumber
         ), '/');

--- a/src/CollectionPaginator.php
+++ b/src/CollectionPaginator.php
@@ -35,11 +35,11 @@ class CollectionPaginator
 
     private function getPageLink($file, $pageNumber)
     {
-        return $this->outputPathResolver->link(
+        return rtrim($this->outputPathResolver->link(
             $file->getRelativePath(),
             $file->getBasename('.blade.php'),
             'html',
             $pageNumber
-        );
+        ), '/');
     }
 }

--- a/src/CollectionPathResolver.php
+++ b/src/CollectionPathResolver.php
@@ -29,7 +29,7 @@ class CollectionPathResolver
 
     private function getDefaultPermalink($data)
     {
-        return slugify($data['filename']);
+        return str_slug($data['filename']);
     }
 
     private function parseShorthand($path, $data)
@@ -64,7 +64,7 @@ class CollectionPathResolver
 
         $value = $dateFormat ? $this->formatDate($data[$param], $dateFormat) : $data[$param];
 
-        return $slugSeparator ? slugify($value, $slugSeparator) : $value;
+        return $slugSeparator ? str_slug($value, $slugSeparator) : $value;
     }
 
     private function formatDate($date, $format)

--- a/src/CollectionPathResolver.php
+++ b/src/CollectionPathResolver.php
@@ -1,0 +1,100 @@
+<?php namespace TightenCo\Jigsaw;
+
+class CollectionPathResolver
+{
+    private $outputPathResolver;
+
+    public function __construct($outputPathResolver)
+    {
+        $this->outputPathResolver = $outputPathResolver;
+    }
+
+    public function link($permalink, $data)
+    {
+        return $this->cleanOutputPath($this->getPath($permalink, $data));
+    }
+
+    private function getPath($permalink, $data)
+    {
+        if (is_callable($permalink)) {
+            return $this->resolve($this->cleanInputPath($permalink->__invoke($data)));
+        }
+
+        if (is_string($permalink) && $permalink) {
+            return $this->parseShorthand($this->cleanInputPath($permalink), $data);
+        }
+
+        return $this->getDefaultPermalink($data);
+    }
+
+    private function getDefaultPermalink($data)
+    {
+        return slugify($data['filename']);
+    }
+
+    private function parseShorthand($path, $data)
+    {
+        preg_match_all('/\{(.*?)\}/', $path, $bracketedParameters);
+
+        if (count($bracketedParameters[0]) == 0) {
+            return $path . '/' . $this->getDefaultPermalink($data);
+        }
+
+        $bracketedParametersReplaced =
+            collect($bracketedParameters[0])->map(function($param) use ($data) {
+                return ['token' => $param, 'value' => $this->getParameterValue($param, $data)];
+            })->reduce(function ($carry, $param) use ($path) {
+                return str_replace($param['token'], $param['value'], $carry);
+            }, $path);
+
+        return $this->resolve($bracketedParametersReplaced);
+    }
+
+    private function getParameterValue($param, $data) {
+        list($param, $dateFormat) = explode('|', trim($param, '{}') . '|');
+        $slugSeparator = ctype_alpha($param[0]) ? null : $param[0];
+
+        if ($slugSeparator) {
+            $param = ltrim($param, $param[0]);
+        }
+
+        if (! isset($data[$param])) {
+            return '';
+        }
+
+        $value = $dateFormat ? $this->formatDate($data[$param], $dateFormat) : $data[$param];
+
+        return $slugSeparator ? slugify($value, $slugSeparator) : $value;
+    }
+
+    private function formatDate($date, $format)
+    {
+        if (is_string($date)) {
+            return strtotime($date) ? date($format, strtotime($date)) : '';
+        }
+
+        return date($format, $date);
+    }
+
+    private function cleanInputPath($path)
+    {
+        return $this->ensureSlashAtBeginningOnly($path);
+    }
+
+    private function cleanOutputPath($path)
+    {
+        $removeDoubleSlashes = preg_replace('/\/\/+/', '/', $path);
+
+        return $this->ensureSlashAtBeginningOnly($removeDoubleSlashes);
+    }
+
+    private function ensureSlashAtBeginningOnly($path)
+    {
+        return '/' . trim($path, '/.');
+    }
+
+    private function resolve($path)
+    {
+        return $this->outputPathResolver->link(dirname($path), basename($path), 'html');
+    }
+}

--- a/src/CollectionPathResolver.php
+++ b/src/CollectionPathResolver.php
@@ -57,7 +57,7 @@ class CollectionPathResolver
 
     private function getDefaultPermalink($data)
     {
-        return str_slug($data['filename']);
+        return str_slug($data['collection']) . '/' . str_slug($data['filename']);
     }
 
     private function parseShorthand($path, $data)
@@ -65,7 +65,7 @@ class CollectionPathResolver
         preg_match_all('/\{(.*?)\}/', $path, $bracketedParameters);
 
         if (count($bracketedParameters[0]) == 0) {
-            return $path . '/' . $this->getDefaultPermalink($data);
+            return $path . '/' . str_slug($data['filename']);
         }
 
         $bracketedParametersReplaced =

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1,11 +1,9 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\PrettyOutputPathResolver;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class BuildCommand extends Command
 {

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,9 +1,7 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
-use TightenCo\Jigsaw\Jigsaw;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command extends SymfonyCommand

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -1,10 +1,7 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
-use TightenCo\Jigsaw\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
+use TightenCo\Jigsaw\Filesystem;
 
 class InitCommand extends Command
 {

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -1,9 +1,7 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class ServeCommand extends Command
 {

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -13,9 +13,9 @@ class DataLoader
 
     public function load($source, $env)
     {
-        return [
-            'site' => array_merge($this->loadConfigData($env), $this->loadCollectionData($source)),
-        ];
+        return $this->makeIterableObject(
+            array_merge($this->loadConfigData($env), $this->loadCollectionData($source))
+        );
     }
 
     private function loadConfigData($env)
@@ -27,6 +27,12 @@ class DataLoader
         }
 
         return array_merge(include $this->basePath . '/config.php', $environmentConfig);
+
+    private function makeIterableObject($array)
+    {
+        return collect($array)->map(function ($item, $_) {
+            return is_array($item) ? new IterableObject($this->makeIterableObject($item)) : $item;
+        });
     }
 
     private function loadCollectionData($source)

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -2,11 +2,13 @@
 
 class DataLoader
 {
+    private $config;
     private $basePath;
     private $collectionDataLoader;
 
-    public function __construct($basePath, $collectionDataLoader)
+    public function __construct($config, $basePath, $collectionDataLoader)
     {
+        $this->config = $config;
         $this->basePath = $basePath;
         $this->collectionDataLoader = $collectionDataLoader;
     }
@@ -26,7 +28,8 @@ class DataLoader
             $environmentConfig = [];
         }
 
-        return array_merge(include $this->basePath . '/config.php', $environmentConfig);
+        return array_merge($this->config, $environmentConfig);
+    }
 
     private function makeIterableObject($array)
     {

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -15,9 +15,10 @@ class DataLoader
 
     public function load($source, $env)
     {
-        return $this->makeIterableObject(
-            array_merge($this->loadConfigData($env), $this->loadCollectionData($source))
-        );
+        $globalSettings = $this->loadConfigData($env);
+        $collectionData = $this->loadCollectionData($source, $globalSettings);
+
+        return $this->makeIterableObject(array_merge($globalSettings, $collectionData));
     }
 
     private function loadConfigData($env)
@@ -38,8 +39,8 @@ class DataLoader
         });
     }
 
-    private function loadCollectionData($source)
+    private function loadCollectionData($source, $globalSettings)
     {
-        return $this->collectionDataLoader->load($source);
+        return $this->collectionDataLoader->load($source, $globalSettings);
     }
 }

--- a/src/FrontMatterParser.php
+++ b/src/FrontMatterParser.php
@@ -13,9 +13,14 @@ class FrontMatterParser
         $this->parser = $parser ?: new Parser;
     }
 
-    public function parse($content)
+    public function parseMarkdown($content)
     {
-        $document = $this->parser->parse($content, false);
+        return $this->parse($content, true);
+    }
+
+    public function parse($content, $parseMarkdown = false)
+    {
+        $document = $this->parser->parse($content, $parseMarkdown);
         $this->frontMatter = $document->getYAML() !== null ? $document->getYAML() : [];
         $this->content = $document->getContent();
 

--- a/src/FrontMatterParser.php
+++ b/src/FrontMatterParser.php
@@ -5,6 +5,8 @@ use Mni\FrontYAML\Parser;
 class FrontMatterParser
 {
     private $parser;
+    public $frontMatter = [];
+    public $content;
 
     public function __construct($parser = null)
     {
@@ -14,8 +16,9 @@ class FrontMatterParser
     public function parse($content)
     {
         $document = $this->parser->parse($content, false);
-        $frontMatter = $document->getYAML() !== null ? $document->getYAML() : [];
-        $documentContent = $document->getContent();
-        return [$frontMatter, $documentContent];
+        $this->frontMatter = $document->getYAML() !== null ? $document->getYAML() : [];
+        $this->content = $document->getContent();
+
+        return $this;
     }
 }

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -33,6 +33,6 @@ class BladeHandler
 
     private function render($file, $data)
     {
-        return $this->viewFactory->file($file->getRealPath(), $data)->render();
+        return $this->viewFactory->file($file->getRealPath(), ['jigsaw' => $data])->render();
     }
 }

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -6,33 +6,52 @@ use TightenCo\Jigsaw\ViewRenderer;
 
 class BladeHandler
 {
+    private $temporaryFilesystem;
     private $view;
 
-    public function __construct(ViewRenderer $viewRenderer)
+    public function __construct($temporaryFilesystem, ViewRenderer $viewRenderer)
     {
+        $this->temporaryFilesystem = $temporaryFilesystem;
         $this->view = $viewRenderer;
     }
 
     public function shouldHandle($file)
     {
-        return ends_with($file->getFilename(), '.blade.php');
+        return str_contains($file->getFilename(), '.blade.');
     }
 
     public function handle($file, $data)
     {
+        if (strtolower($file->getExtension()) === 'php') {
+            $extension = 'html';
+            $sourceExtension = '.blade.php';
+            $contents = $this->render($file->getRealPath(), new ViewData($data));
+        } else {
+            $extension = $file->getExtension();
+            $sourceExtension = '.blade.' . $extension;
+            $contents = $this->renderCopy($file->getRealPath(), new ViewData($data));
+        }
+
         return [
             new OutputFile(
                 $file->getRelativePath(),
-                $file->getBasename('.blade.php'),
-                'html',
-                $this->render($file, new ViewData($data)),
+                $file->getBasename($sourceExtension),
+                $extension,
+                $contents,
                 $data
             )
         ];
     }
 
-    private function render($file, $data)
+    private function renderCopy($path, $data)
     {
-        return $this->view->render($file->getRealPath(), $data);
+        return $this->temporaryFilesystem->copy($path, function ($copy) use ($data) {
+            return $this->render($copy, $data);
+        }, '.blade.php');
+    }
+
+    private function render($path, $data)
+    {
+        return $this->view->render($path, $data);
     }
 }

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -22,32 +22,17 @@ class BladeHandler
 
     public function handle($file, $data)
     {
-        if (strtolower($file->getExtension()) === 'php') {
-            $extension = 'html';
-            $sourceExtension = '.blade.php';
-            $contents = $this->render($file->getRealPath(), new ViewData($data));
-        } else {
-            $extension = $file->getExtension();
-            $sourceExtension = '.blade.' . $extension;
-            $contents = $this->renderCopy($file->getRealPath(), new ViewData($data));
-        }
+        $extension = strtolower($file->getExtension());
 
         return [
             new OutputFile(
                 $file->getRelativePath(),
-                $file->getBasename($sourceExtension),
-                $extension,
-                $contents,
+                $file->getFilenameWithoutExtension(),
+                $extension == 'php' | $extension == 'html' ? 'html' : $extension,
+                $this->render($file->getRealPath(), new ViewData($data)),
                 $data
             )
         ];
-    }
-
-    private function renderCopy($path, $data)
-    {
-        return $this->temporaryFilesystem->copy($path, function ($copy) use ($data) {
-            return $this->render($copy, $data);
-        }, '.blade.php');
     }
 
     private function render($path, $data)

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -2,6 +2,7 @@
 
 use Illuminate\View\Factory;
 use TightenCo\Jigsaw\OutputFile;
+use TightenCo\Jigsaw\ViewData;
 
 class BladeHandler
 {
@@ -24,7 +25,7 @@ class BladeHandler
                 $file->getRelativePath(),
                 $file->getBasename('.blade.php'),
                 'html',
-                $this->render($file, $data),
+                $this->render($file, new ViewData($data)),
                 $data
             )
         ];

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -1,16 +1,16 @@
 <?php namespace TightenCo\Jigsaw\Handlers;
 
-use Illuminate\View\Factory;
 use TightenCo\Jigsaw\OutputFile;
 use TightenCo\Jigsaw\ViewData;
+use TightenCo\Jigsaw\ViewRenderer;
 
 class BladeHandler
 {
-    private $viewFactory;
+    private $view;
 
-    public function __construct(Factory $viewFactory)
+    public function __construct(ViewRenderer $viewRenderer)
     {
-        $this->viewFactory = $viewFactory;
+        $this->view = $viewRenderer;
     }
 
     public function shouldHandle($file)
@@ -33,6 +33,6 @@ class BladeHandler
 
     private function render($file, $data)
     {
-        return $this->viewFactory->file($file->getRealPath(), ['jigsaw' => $data])->render();
+        return $this->view->render($file->getRealPath(), $data);
     }
 }

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -50,7 +50,7 @@ class CollectionItemHandler
 
             return new OutputFile(
                 dirname($link),
-                basename($link),
+                basename($link, '.' . $file->extension()),
                 $file->extension(),
                 $file->contents(),
                 $file->data());

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -49,7 +49,8 @@ class CollectionItemHandler
             return $handler->shouldHandle($file);
         });
         $collectionName = $this->getCollectionName($file);
-        $handledFiles = $handler->handle($file, $data);
+        $defaultVariables = array_get($this->collectionSettings[$collectionName], 'variables', []);
+        $handledFiles = $handler->handle($file, array_merge($defaultVariables, $data));
 
         return collect($handledFiles)->map(function ($file) use ($collectionName) {
             $link = $this->getCollectionData($file, $collectionName)->getLink();

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -45,13 +45,15 @@ class CollectionItemHandler
         $viewData = ViewData::withCollectionItem($data, $this->getCollectionName($file), $file->getFilenameWithoutExtension());
         $handledFiles = $handler->handle(new ParsedInputFile($file), $viewData);
 
-        return collect($handledFiles)->map(function ($file) {
+        return $handledFiles->map(function ($file, $templateKey) {
+            $link = $templateKey ? $file->data()->link->get($templateKey) : (string) $file->data()->link;
+
             return new OutputFile(
-                dirname($file->data()->link),
-                basename($file->data()->link),
+                dirname($link),
+                basename($link),
                 $file->extension(),
                 $file->contents(),
                 $file->data());
-        })->all();
+        })->values();
     }
 }

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -1,6 +1,8 @@
 <?php namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\OutputFile;
+use TightenCo\Jigsaw\ParsedInputFile;
+use TightenCo\Jigsaw\ViewData;
 
 class CollectionItemHandler
 {
@@ -36,26 +38,22 @@ class CollectionItemHandler
         return substr($file->topLevelDirectory(), 1);
     }
 
-    private function getCollectionData($file, $collectionName)
-    {
-        return collect($file->getCollectionData($collectionName))->first(function($_, $item) use ($file) {
-            return $item->getFilename() === $file->name();
-        });
-    }
-
     public function handle($file, $data)
     {
         $handler = $this->handlers->first(function ($_, $handler) use ($file) {
             return $handler->shouldHandle($file);
         });
-        $collectionName = $this->getCollectionName($file);
-        $defaultVariables = array_get($this->collectionSettings[$collectionName], 'variables', []);
-        $handledFiles = $handler->handle($file, array_merge($defaultVariables, $data));
 
-        return collect($handledFiles)->map(function ($file) use ($collectionName) {
-            $link = $this->getCollectionData($file, $collectionName)->getLink();
+        $viewData = ViewData::withCollectionItem($data, $this->getCollectionName($file), $file->getFilenameWithoutExtension());
+        $handledFiles = $handler->handle(new ParsedInputFile($file), $viewData);
 
-            return new OutputFile(dirname($link), basename($link), $file->extension(), $file->contents(), $file->data());
+        return collect($handledFiles)->map(function ($file) {
+            return new OutputFile(
+                dirname($file->data()->link),
+                basename($file->data()->link),
+                $file->extension(),
+                $file->contents(),
+                $file->data());
         })->all();
     }
 }

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -7,13 +7,11 @@ use TightenCo\Jigsaw\ViewData;
 class CollectionItemHandler
 {
     private $collectionSettings;
-    private $outputPathResolver;
     private $handlers;
 
-    public function __construct($collectionSettings, $outputPathResolver, $handlers)
+    public function __construct($collectionSettings, $handlers)
     {
         $this->collectionSettings = collect($collectionSettings);
-        $this->outputPathResolver = $outputPathResolver;
         $this->handlers = collect($handlers);
     }
 

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -2,7 +2,6 @@
 
 use TightenCo\Jigsaw\Filesystem;
 use TightenCo\Jigsaw\OutputFile;
-use Illuminate\Contracts\View\Factory;
 
 class DefaultHandler
 {

--- a/src/Handlers/IgnoredHandler.php
+++ b/src/Handlers/IgnoredHandler.php
@@ -4,7 +4,7 @@ class IgnoredHandler
 {
     public function shouldHandle($file)
     {
-        return preg_match('/(^_|\/_)/', $file->getRelativePathname()) === 1;
+        return preg_match('/(^(_|\.)|\/(_|\.))/', $file->getRelativePathname()) === 1;
     }
 
     public function handle($file, $data)

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -35,11 +35,12 @@ class MarkdownHandler
         }
 
         return collect($data->extends)->map(function($layout) use ($file, $data) {
+            $extension = $this->view->getExtension($layout);
 
             return new OutputFile(
                 $file->getRelativePath(),
                 $file->getFilenameWithoutExtension(),
-                'html',
+                $extension == 'php' | $extension == 'html' ? 'html' : $extension,
                 $this->render($data, $layout),
                 $data
             );

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -34,6 +34,10 @@ class MarkdownHandler
             );
         }
 
+        if (! $data->extends) {
+            return;
+        }
+
         return [
             new OutputFile(
                 $file->getRelativePath(),

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -58,7 +58,7 @@ class MarkdownHandler
 
     private function parseFile($file)
     {
-        return $this->parser->parse($file->getContents());
+        return $this->parser->parseMarkdown($file->getContents());
     }
 
     private function compileToBlade($data)

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -1,21 +1,21 @@
 <?php namespace TightenCo\Jigsaw\Handlers;
 
-use Illuminate\Contracts\View\Factory;
 use TightenCo\Jigsaw\FrontMatterParser;
 use TightenCo\Jigsaw\OutputFile;
 use TightenCo\Jigsaw\ViewData;
+use TightenCo\Jigsaw\ViewRenderer;
 
 class MarkdownHandler
 {
     private $temporaryFilesystem;
-    private $viewFactory;
     private $parser;
+    private $view;
 
-    public function __construct($temporaryFilesystem, Factory $viewFactory, FrontMatterParser $parser)
+    public function __construct($temporaryFilesystem, FrontMatterParser $parser, ViewRenderer $viewRenderer)
     {
         $this->temporaryFilesystem = $temporaryFilesystem;
-        $this->viewFactory = $viewFactory;
         $this->parser = $parser;
+        $this->view = $viewRenderer;
     }
 
     public function shouldHandle($file)
@@ -52,7 +52,7 @@ class MarkdownHandler
     private function render($viewData)
     {
         return $this->temporaryFilesystem->put($this->compileToBlade($viewData), function ($path) use ($viewData) {
-            return $this->viewFactory->file($path, ['jigsaw' => $viewData])->render();
+            return $this->view->render($path, $viewData);
         }, '.blade.php');
     }
 

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -25,7 +25,6 @@ class MarkdownHandler
     public function handle($file, $data)
     {
         $document = $this->parseFile($file);
-
         $data = array_merge($data, ['section' => 'markdown'], $document->getYAML());
 
         return [

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -1,7 +1,7 @@
 <?php namespace TightenCo\Jigsaw\Handlers;
 
-use Mni\FrontYAML\Parser;
 use Illuminate\Contracts\View\Factory;
+use TightenCo\Jigsaw\FrontMatterParser;
 use TightenCo\Jigsaw\OutputFile;
 use TightenCo\Jigsaw\ViewData;
 
@@ -11,11 +11,11 @@ class MarkdownHandler
     private $viewFactory;
     private $parser;
 
-    public function __construct($temporaryFilesystem, Factory $viewFactory, $parser = null)
+    public function __construct($temporaryFilesystem, Factory $viewFactory, FrontMatterParser $parser)
     {
         $this->temporaryFilesystem = $temporaryFilesystem;
         $this->viewFactory = $viewFactory;
-        $this->parser = $parser ?: new Parser;
+        $this->parser = $parser;
     }
 
     public function shouldHandle($file)
@@ -26,7 +26,7 @@ class MarkdownHandler
     public function handle($file, $data)
     {
         if (! $file->hasBeenParsed()) {
-        $document = $this->parseFile($file);
+            $document = $this->parseFile($file);
             $data = new ViewData(
                 $data->put('section', 'content')
                 ->merge($document->frontMatter)

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -47,7 +47,7 @@ class PaginatedPageHandler
                     new ViewData($data->put('pagination', $page))
                 ),
                 $data,
-                $page['page']
+                $page['currentPage']
             );
         })->all();
     }

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -40,11 +40,14 @@ class PaginatedPageHandler
         return $pages->map(function ($page) use ($file, $data, $content) {
             return new OutputFile(
                 $file->getRelativePath(),
-                $file->getBasename('.blade.php'),
+                $file->getFilenameWithoutExtension(),
                 'html',
                 $this->render(
                     $content->content,
-                    new ViewData($data->put('pagination', $page))
+                    new ViewData(
+                        $data->put('pagination', $page)
+                        ->put('link', $page['pages'][$page['currentPage']])
+                    )
                 ),
                 $data,
                 $page['currentPage']

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -55,7 +55,7 @@ class PaginatedPageHandler
     private function render($bladeContent, $data)
     {
         return $this->temporaryFilesystem->put($bladeContent, function ($path) use ($data) {
-            return $this->viewFactory->file($path, $data)->render();
+            return $this->viewFactory->file($path, ['jigsaw' => $data])->render();
         }, '.blade.php');
     }
 }

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -1,23 +1,23 @@
 <?php namespace TightenCo\Jigsaw\Handlers;
 
-use Illuminate\View\Factory;
 use TightenCo\Jigsaw\FrontMatterParser;
 use TightenCo\Jigsaw\OutputFile;
 use TightenCo\Jigsaw\ViewData;
+use TightenCo\Jigsaw\ViewRenderer;
 
 class PaginatedPageHandler
 {
     private $paginator;
-    private $viewFactory;
     private $parser;
     private $temporaryFilesystem;
+    private $viewFactory;
 
-    public function __construct($paginator, Factory $viewFactory, FrontMatterParser $parser, $temporaryFilesystem)
+    public function __construct($paginator, FrontMatterParser $parser, $temporaryFilesystem, ViewRenderer $viewRenderer)
     {
         $this->paginator = $paginator;
-        $this->viewFactory = $viewFactory;
         $this->parser = $parser;
         $this->temporaryFilesystem = $temporaryFilesystem;
+        $this->view = $viewRenderer;
     }
 
     public function shouldHandle($file)
@@ -58,7 +58,7 @@ class PaginatedPageHandler
     private function render($bladeContent, $data)
     {
         return $this->temporaryFilesystem->put($bladeContent, function ($path) use ($data) {
-            return $this->viewFactory->file($path, ['jigsaw' => $data])->render();
+            return $this->view->render($path, $data);
         }, '.blade.php');
     }
 }

--- a/src/InputFile.php
+++ b/src/InputFile.php
@@ -25,7 +25,14 @@ class InputFile
 
     public function getFilenameWithoutExtension()
     {
-        return $this->getBasename('.' . $this->getExtension());
+        return $this->getBasename('.' . $this->getFullExtension());
+    }
+
+    public function getFullExtension()
+    {
+        $extension = $this->getExtension();
+
+        return strpos($this->getBasename(), '.blade.' . $extension) > 0 ? 'blade.' . $extension : $extension;
     }
 
     public function hasBeenParsed()

--- a/src/InputFile.php
+++ b/src/InputFile.php
@@ -2,8 +2,8 @@
 
 class InputFile
 {
-    private $file;
-    private $basePath;
+    protected $file;
+    protected $basePath;
 
     public function __construct($file, $basePath)
     {
@@ -15,16 +15,22 @@ class InputFile
     {
         $parts = explode('/', $this->relativePath());
 
-        if (count($parts) == 1) {
-            return '';
-        }
-
-        return $parts[0];
+        return count($parts) == 1 ? '' : $parts[0];
     }
 
     public function relativePath()
     {
         return str_replace($this->basePath . '/', '', $this->file->getPathname());
+    }
+
+    public function getFilenameWithoutExtension()
+    {
+        return $this->getBasename('.' . $this->getExtension());
+    }
+
+    public function hasBeenParsed()
+    {
+        return false;
     }
 
     public function __call($method, $args)

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -1,0 +1,25 @@
+<?php namespace TightenCo\Jigsaw;
+
+use ArrayAccess;
+use Illuminate\Support\Collection as BaseCollection;
+
+class IterableObject extends BaseCollection implements ArrayAccess
+{
+    public function __get($key)
+    {
+        if (! $this->has($key)) {
+            return;
+        }
+
+        $element = $this->get($key);
+
+        return is_array($element) ? new self($element) : $element;
+    }
+
+    public function offsetGet($key)
+    {
+        $element = $this->items[$key];
+
+        return is_array($element) ? new self($element) : $element;
+    }
+}

--- a/src/IterableObjectWithDefault.php
+++ b/src/IterableObjectWithDefault.php
@@ -1,0 +1,11 @@
+<?php namespace TightenCo\Jigsaw;
+
+use TightenCo\Jigsaw\IterableObject;
+
+class IterableObjectWithDefault extends IterableObject
+{
+    public function __toString()
+    {
+        return $this->first() ?: '';
+    }
+}

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -1,9 +1,5 @@
 <?php namespace TightenCo\Jigsaw;
 
-use Illuminate\Contracts\View\Factory;
-use Illuminate\Support\Str;
-use TightenCo\Jigsaw\Filesystem;
-
 class Jigsaw
 {
     private $dataLoader;

--- a/src/MarkdownEngine.php
+++ b/src/MarkdownEngine.php
@@ -1,0 +1,46 @@
+<?php namespace TightenCo\Jigsaw;
+
+use Exception;
+use Illuminate\View\Engines\EngineInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Throwable;
+use TightenCo\Jigsaw\Filesystem;
+
+class MarkdownEngine implements EngineInterface
+{
+    private $parser;
+    private $file;
+    private $sourcePath;
+
+    public function __construct($parser, $filesystem, $sourcePath)
+    {
+        $this->parser = $parser;
+        $this->file = $filesystem;
+        $this->sourcePath = $sourcePath;
+    }
+
+    public function get($path, array $data = [])
+    {
+        return $this->evaluatePath($path);
+    }
+
+    protected function evaluatePath($path)
+    {
+        try {
+            $file = $this->file->get($path);
+
+            if ($file) {
+                return $this->parser->parseMarkdown($file)->content;
+            }
+        } catch (Exception $e) {
+            $this->handleViewException($e);
+        } catch (Throwable $e) {
+            $this->handleViewException(new FatalThrowableError($e));
+        }
+    }
+
+    protected function handleViewException(Exception $e)
+    {
+        throw $e;
+    }
+}

--- a/src/OutputFile.php
+++ b/src/OutputFile.php
@@ -48,4 +48,9 @@ class OutputFile
     {
         return $this->page;
     }
+
+    public function getCollectionData($collectionName)
+    {
+        return $this->data['site'][$collectionName];
+    }
 }

--- a/src/OutputFile.php
+++ b/src/OutputFile.php
@@ -48,9 +48,4 @@ class OutputFile
     {
         return $this->page;
     }
-
-    public function getCollectionData($collectionName)
-    {
-        return $this->data['site'][$collectionName];
-    }
 }

--- a/src/ParsedInputFile.php
+++ b/src/ParsedInputFile.php
@@ -1,0 +1,17 @@
+<?php namespace TightenCo\Jigsaw;
+
+class ParsedInputFile extends InputFile
+{
+    protected $file;
+    protected $basePath;
+
+    public function __construct(InputFile $inputFile)
+    {
+        parent::__construct($inputFile->file, $inputFile->basePath);
+    }
+
+    public function hasBeenParsed()
+    {
+        return true;
+    }
+}

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -83,6 +83,7 @@ class SiteBuilder
     private function getMeta($file)
     {
         $meta['filename'] = $file->getFilenameWithoutExtension();
+        $meta['extension'] = $file->getFullExtension();
         $meta['link'] = rtrim($this->outputPathResolver->link($file->getRelativePath(), $meta['filename'], 'html'), '/');
 
         return $meta;

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -63,7 +63,7 @@ class SiteBuilder
 
     private function handle($file, $data)
     {
-        return $this->getHandler($file)->handle($file, $data);
+        return $this->getHandler($file)->handle($file, $data->merge($this->getMeta($file)));
     }
 
     private function buildFile($file, $dest)
@@ -78,6 +78,14 @@ class SiteBuilder
         return collect($this->handlers)->first(function ($_, $handler) use ($file) {
             return $handler->shouldHandle($file);
         });
+    }
+
+    private function getMeta($file)
+    {
+        $meta['filename'] = $file->getFilenameWithoutExtension();
+        $meta['link'] = rtrim($this->outputPathResolver->link($file->getRelativePath(), $meta['filename'], 'html'), '/');
+
+        return $meta;
     }
 
     private function getOutputDirectory($file)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -63,7 +63,7 @@ class SiteBuilder
 
     private function handle($file, $data)
     {
-        return $this->getHandler($file)->handle($file, $data->merge($this->getMeta($file)));
+        return $this->getHandler($file)->handle($file, $data->merge($this->getMeta($file, $data)));
     }
 
     private function buildFile($file, $dest)
@@ -80,11 +80,13 @@ class SiteBuilder
         });
     }
 
-    private function getMeta($file)
+    private function getMeta($file, $data)
     {
         $meta['filename'] = $file->getFilenameWithoutExtension();
         $meta['extension'] = $file->getFullExtension();
         $meta['link'] = rtrim($this->outputPathResolver->link($file->getRelativePath(), $meta['filename'], 'html'), '/');
+        $meta['path'] = trim($meta['link'], '/');
+        $meta['url'] = rtrim(array_get($data, 'baseUrl'), '/') . '/' . trim($meta['link'], '/');
 
         return $meta;
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,25 +1,5 @@
 <?php
 
-if (! function_exists('slugify')) {
-    /**
-     * Convert a filename into a URL slug.
-     *
-     * @param  string  $filename
-     * @param  string  $separator
-     * @return string
-     */
-    function slugify($filename, $separator = '-')
-    {
-        setlocale(LC_ALL, 'en_US.UTF8');
-        $convertSpecialCharacters = iconv('UTF-8', 'ASCII//TRANSLIT', trim($filename));
-        $removePunctuation = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $convertSpecialCharacters);
-        $lowerCase = strtolower($removePunctuation);
-        $slug = preg_replace("/[_|+ -]+/", $separator, $lowerCase);
-
-        return $slug;
-    }
-}
-
 if (! function_exists('public_path')) {
     /**
      * Get the path to the public folder.

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,5 +1,25 @@
 <?php
 
+if (! function_exists('slugify')) {
+    /**
+     * Convert a filename into a URL slug.
+     *
+     * @param  string  $filename
+     * @param  string  $delimiter
+     * @return string
+     */
+    function slugify($filename, $delimiter = '-')
+    {
+        setlocale(LC_ALL, 'en_US.UTF8');
+        $convertSpecialCharacters = iconv('UTF-8', 'ASCII//TRANSLIT', trim($filename));
+        $removePunctuation = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $convertSpecialCharacters);
+        $lowerCase = strtolower($removePunctuation);
+        $delimitedSlug = preg_replace("/[_|+ -]+/", $delimiter, $lowerCase);
+
+        return $delimitedSlug;
+    }
+}
+
 if (! function_exists('public_path')) {
     /**
      * Get the path to the public folder.

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -5,18 +5,18 @@ if (! function_exists('slugify')) {
      * Convert a filename into a URL slug.
      *
      * @param  string  $filename
-     * @param  string  $delimiter
+     * @param  string  $separator
      * @return string
      */
-    function slugify($filename, $delimiter = '-')
+    function slugify($filename, $separator = '-')
     {
         setlocale(LC_ALL, 'en_US.UTF8');
         $convertSpecialCharacters = iconv('UTF-8', 'ASCII//TRANSLIT', trim($filename));
         $removePunctuation = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $convertSpecialCharacters);
         $lowerCase = strtolower($removePunctuation);
-        $delimitedSlug = preg_replace("/[_|+ -]+/", $delimiter, $lowerCase);
+        $slug = preg_replace("/[_|+ -]+/", $separator, $lowerCase);
 
-        return $delimitedSlug;
+        return $slug;
     }
 }
 

--- a/src/TemporaryFilesystem.php
+++ b/src/TemporaryFilesystem.php
@@ -19,6 +19,7 @@ class TemporaryFilesystem
         $this->filesystem->put($path, $contents);
         $result = $callback($path);
         $this->filesystem->delete($path);
+
         return $result;
     }
 }

--- a/src/TemporaryFilesystem.php
+++ b/src/TemporaryFilesystem.php
@@ -15,8 +15,27 @@ class TemporaryFilesystem
 
     public function put($contents, $callback, $extension = '')
     {
-        $path = $this->tempPath . '/' . Str::quickRandom(32) . $extension;
+        $path = $this->buildTempPath($extension);
         $this->filesystem->put($path, $contents);
+
+        return $this->cleanup($path, $callback);
+    }
+
+    public function copy($source, $callback, $extension = '')
+    {
+        $path = $this->buildTempPath($extension);
+        $this->filesystem->copy($source, $path);
+
+        return $this->cleanup($path, $callback);
+    }
+
+    private function buildTempPath($extension)
+    {
+        return $this->tempPath . '/' . Str::quickRandom(32) . $extension;
+    }
+
+    private function cleanup($path, $callback)
+    {
         $result = $callback($path);
         $this->filesystem->delete($path);
 

--- a/src/ViewData.php
+++ b/src/ViewData.php
@@ -35,8 +35,16 @@ class ViewData extends IterableObject
     {
         if ($this->has($collection)) {
             $this->item = $this->get($collection)->get($item);
+            $this->addSingularCollectionReference($collection);
             $this->setGloballyAvailableItemVariables();
         }
+    }
+
+    private function addSingularCollectionReference($collection)
+    {
+        if (str_singular($collection) != $collection) {
+            $this->{str_singular($collection)} = $this->item;
+        };
     }
 
     private function setGloballyAvailableItemVariables()

--- a/src/ViewData.php
+++ b/src/ViewData.php
@@ -1,5 +1,6 @@
 <?php namespace TightenCo\Jigsaw;
 
+use Exception;
 use TightenCo\Jigsaw\IterableObject;
 
 class ViewData extends IterableObject
@@ -26,7 +27,7 @@ class ViewData extends IterableObject
         $helper = $this->has('helpers') ? $this->helpers->{$name} : null;
 
         return $helper ?: function() use ($name) {
-            throw new \Exception("No helper function named '$name' in 'config.php'.");
+            throw new Exception("No helper function named '$name' in 'config.php'.");
         };
     }
 

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -1,0 +1,31 @@
+<?php namespace TightenCo\Jigsaw;
+
+use Illuminate\View\Factory;
+
+class ViewRenderer
+{
+    private $viewFactory;
+
+    public function __construct(Factory $viewFactory)
+    {
+        $this->viewFactory = $viewFactory;
+    }
+
+    public function render($path, $data)
+    {
+        $data = $this->addMeta($data);
+
+        return $this->viewFactory->file(
+            $path,
+            array_merge(['jigsaw' => $data], $data->all())
+        )->render();
+    }
+
+    private function addMeta($data)
+    {
+        $data['path'] = trim(array_get($data, 'link'), '/');
+        $data['url'] = rtrim(array_get($data, 'url'), '/') . '/' . trim(array_get($data, 'link'), '/');
+
+        return $data;
+    }
+}

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -18,7 +18,13 @@ class ViewRenderer
 
     private function addBladeExtensions()
     {
+        $this->viewFactory->addExtension('md', 'markdown');
+        $this->viewFactory->addExtension('markdown', 'markdown');
+        $this->viewFactory->addExtension('blade.md', 'blade-markdown');
+        $this->viewFactory->addExtension('blade.markdown', 'blade-markdown');
+
         collect($this->allowedBladeExtensions)->each(function ($extension) {
+            $this->viewFactory->addExtension($extension, 'php');
             $this->viewFactory->addExtension('blade.' . $extension, 'blade');
         });
     }

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -5,10 +5,22 @@ use Illuminate\View\Factory;
 class ViewRenderer
 {
     private $viewFactory;
+    private $allowedBladeExtensions = [
+        'js', 'json', 'xml', 'rss', 'txt', 'text', 'html'
+    ];
 
     public function __construct(Factory $viewFactory)
     {
         $this->viewFactory = $viewFactory;
+        $this->finder = $this->viewFactory->getFinder();
+        $this->addBladeExtensions();
+    }
+
+    private function addBladeExtensions()
+    {
+        collect($this->allowedBladeExtensions)->each(function ($extension) {
+            $this->viewFactory->addExtension('blade.' . $extension, 'blade');
+        });
     }
 
     public function render($path, $data)
@@ -19,6 +31,11 @@ class ViewRenderer
             $path,
             array_merge(['jigsaw' => $data], $data->all())
         )->render();
+    }
+
+    public function getExtension($bladeViewPath)
+    {
+        return strtolower(pathinfo($this->finder->find($bladeViewPath), PATHINFO_EXTENSION));
     }
 
     private function updateMetaForCollectionItem($data)

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -13,7 +13,7 @@ class ViewRenderer
 
     public function render($path, $data)
     {
-        $data = $this->addMeta($data);
+        $data = $this->updateMetaForCollectionItem($data);
 
         return $this->viewFactory->file(
             $path,
@@ -21,10 +21,13 @@ class ViewRenderer
         )->render();
     }
 
-    private function addMeta($data)
+    private function updateMetaForCollectionItem($data)
     {
-        $data['path'] = trim(array_get($data, 'link'), '/');
-        $data['url'] = rtrim(array_get($data, 'url'), '/') . '/' . trim(array_get($data, 'link'), '/');
+        if ($data->item) {
+            $data->link = $data->item->link;
+            $data->path = $data->item->path;
+            $data->url = $data->item->url;
+        }
 
         return $data;
     }

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -35,7 +35,7 @@ class ViewRenderer
 
         return $this->viewFactory->file(
             $path,
-            array_merge(['jigsaw' => $data], $data->all())
+            array_merge(['jigsaw' => $data], $data->toArray())
         )->render();
     }
 


### PR DESCRIPTION
(Addresses some of the outstanding to-do items in https://github.com/tightenco/jigsaw/pull/59 and build on Adam's collection support...)

### Enhanced permalink support:
- `path` key is optional in `collections.php`; if not specified, collection item path will default to slugified filename
- Global `slugify()` helper added for easy use in `path` closure, helper functions, or Blade templates
- Shorthand for easily specifying common permalink structures
    - `path` key can be a string rather than a closure; if it's a string, any bracketed parameters like `{filename}` will be replaced with values
    - prepending a separator to a parameter name will slugify that parameter, using that separator (e.g. `{+filename}` will yield `the+slugified+filename`)
    - any dates from YAML front matter can be formatted using PHP date formatting codes, by following the parameter name with a pipe: `{date|Y/m/d}`, for example, yields `2016/08/29`.
    - if no parameters are included, the slugified filename will be appended by default. This allows users to simply specify a collection subdirectory: `'path' => 'posts'` will yield item URLs like `/posts/the-slugified-filename`.

Examples:
```
'path' => 'people'                                //   ./people/the-slugified-filename
'path' => 'people/{-filename}'                    //   ./people/the-slugified-filename
'path' => '{collection}/{date|Y}/{title}'         //   ./people/2016/The Item Title
'path' => '{collection}/{date|Y/m/d}/{+title}'    //   ./people/2016/08/29/the+item+title
```

### Default frontmatter variables:
- Add support for default frontmatter variables at the collection level, by specifying a `variables` key in `collections.php`:
```
'posts' => [
    'variables' => [
        'author' => 'Editorial Staff'
    ],
...
```

### Sorting collections:
- Add support for sorting collections by one or more criteria specified in `collections.php`.
- `sort` can contain a single variable name, or an array of multiple variables for a hierarchical sort.
- Sort order defaults to ascending; variable names can optionally be prepended with `+`.
- Variable names can be prepended with `-` for a descending sort order.
```
'posts' => [
    'sort' => '-date', 
...
```
or
```
'posts' => [
    'sort' => ['-date', '+author'], 
...
```

### Collection items contain a reference to next/previous items 
- Next/previous collection items are based on collection's default sort order
- e.g. `$jigsaw->item->next()->title` or `$jigsaw->item->previous()->path`

### Collections can exist without templates
- The `extends` directive can be omitted from the YAML front matter of a collection's items, allowing for collections that aren't tied to a particular template. 

### Access Jigsaw collections as Illuminate collections
- For example, `@foreach ($jigsaw->people->sortBy('age') as $person)` or `$jigsaw->products->sum('price')`
- Can even use helper functions defined in `config.php` or `collections.php`: 
```
@foreach ($jigsaw->products->sortByDesc(function ($data) { return $data->priceWithTax(); })
```
- Available anywhere on the site

### Additional pagination variables
- `$jigsaw->pagination->first`, `last`, `currentPage`, `totalPages`
- `$jigsaw->pagination->pages` can be iterated over to build numeric page links (`1` | `2` | `3`), or individual pages can be referenced as `$jigsaw->pagination->pages[1]`

### Helper functions
- Any helper functions defined in `collections.php` under the `helpers => []` key are available within Blade templates for a collection item; previously, they were only available in an index template when iterating over a collection. 
- Helper functions can also be defined globally in `config.php` and referenced in any Blade template as `$jigsaw->functionName($parameter)`

### Metadata
- available in Blade templates for all pages (including collection items and regular pages)
- `filename` displays current page's filename (without extension)
- `extension` displays current page's file extension (e.g. `md`, `blade.php`, etc.)
- `path` is path to current page, relative to site root
- `url` concatenates the site base url (if specified in `config.php`) with `path` for fully-qualified url to current page
- for collection items, `collection` displays the name of the collection an item belongs to

