### PR TITLE
Allow for generating files with endings other than `.html`

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -17,11 +17,12 @@ use TightenCo\Jigsaw\Handlers\DefaultHandler;
 use TightenCo\Jigsaw\Handlers\MarkdownHandler;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\TemporaryFilesystem;
+use TightenCo\Jigsaw\ViewFactory;
 
-if (file_exists(__DIR__.'/vendor/autoload.php')) {
-    require __DIR__.'/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
 } else {
-    require __DIR__.'/../../autoload.php';
+    require __DIR__ . '/../../autoload.php';
 }
 
 // Config
@@ -40,7 +41,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
     });
 
     $finder = new FileViewFinder(new Filesystem, [$sourcePath]);
-    return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
+    return new ViewFactory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });
 
 $container->bind(BladeHandler::class, function ($c) {

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -7,6 +7,10 @@ class BladeHandler
 {
     private $viewFactory;
 
+    protected $extensions = [
+        'php' => 'html',
+    ];
+
     public function __construct(Factory $viewFactory)
     {
         $this->viewFactory = $viewFactory;
@@ -14,13 +18,28 @@ class BladeHandler
 
     public function canHandle($file)
     {
-        return ends_with($file->getFilename(), '.blade.php');
+        return preg_match('@(.+).blade.(\w+)@', $file->getFilename());
     }
 
     public function handle($file, $data)
     {
-        $filename = $file->getBasename('.blade.php') . '.html';
+        $filename = $this->getCompiledName($file);
         return new ProcessedFile($filename, $file->getRelativePath(), $this->render($file, $data));
+    }
+
+    private function getCompiledName($file)
+    {
+        preg_match('@(.+)\.blade\.(\w+)@', $file->getFilename(), $matches);
+        return $matches[1] . '.' . $this->mutateExtension($matches[2]);
+    }
+
+    private function mutateExtension($extension)
+    {
+        if (isset($this->extensions[$extension])) {
+            return $this->extensions[$extension];
+        }
+
+        return $extension;
     }
 
     public function render($file, $data)

--- a/src/ViewFactory.php
+++ b/src/ViewFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TightenCo\Jigsaw;
+
+use Illuminate\View\Factory;
+
+class ViewFactory extends Factory
+{
+
+    /**
+     * @inheritdoc
+     */
+    protected function getExtension($path)
+    {
+        if (preg_match('@(.+).blade.(\w+)@', $path)) {
+            return 'blade.php';
+        }
+
+        return parent::getExtension($path);
+    }
+}


### PR DESCRIPTION
Referencing issue #56.

This allow any file in the format `abc.blade.xxx` to be compiled to `abc.xxx` using blade template.

It was necessary to overwrite view factory because the compile engine is selected based on file extension and it's hard-coded in `$this->extensions` property. It would be possible to extend extensions property by end user to map their custom extension to blade engine, but I think compiling every .blade.xxx file is much easier and cleaner.

Example (using #46 ).

File `source/feed.blade.xml`:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
    <channel>
        <title>{{ $site_title }}</title>
        <description>{{ $site_description }}</description>
        <link>http://example.com</link>
        <atom:link href="http://example.com/feed.xml" rel="self" type="application/rss+xml"/>
        <pubDate>{{ (new DateTime)->format(DATE_ATOM) }}</pubDate>
        <lastBuildDate>{{ (new DateTime)->format(DATE_ATOM) }}</lastBuildDate>
        <generator>Blade templating engine</generator>
    </channel>
</rss>
```

Will be compiled to `build_local/feed.xml`:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
    <channel>
        <title>Hello World</title>
        <description>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque mattis vestibulum est ut facilisis. In porta quis diam in efficitur. Donec ligula tellus, sagittis id nunc eu, iaculis ullamcorper neque. </description>
        <link>http://example.com</link>
        <atom:link href="http://example.com/feed.xml" rel="self" type="application/rss+xml"/>
        <pubDate>2016-09-10T22:17:38+02:00</pubDate>
        <lastBuildDate>2016-09-10T22:17:38+02:00</lastBuildDate>
        <generator>Blade templating engine</generator>
    </channel>
</rss>
```
