### PR TITLE
Add ability to register custom blade tags

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -28,14 +28,36 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
 $cachePath = getcwd() . '/_tmp';
 $buildPath = getcwd() . '/build';
 $sourcePath = getcwd() . '/source';
+$bladePath = getcwd() . '/blade';
 
 $container = new Container;
 
-$container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath) {
+$container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath, $bladePath) {
     $resolver = new EngineResolver;
 
-    $resolver->register('blade', function () use ($cachePath) {
+    $resolver->register('blade', function () use ($cachePath, $bladePath) {
         $compiler = new BladeCompiler(new Filesystem, $cachePath);
+
+        if (is_dir($bladePath)) {
+            $directives = collect((new Filesystem())->allFiles($bladePath));
+
+            $directives->filter(function ($file) {
+                return ends_with($file->getFilename(), '.php') && !ends_with($file->getFilename(), '.raw.php');
+            })->each(function ($file) use ($compiler) {
+                $compiler->directive($file->getBasename('.php'), function ($expression) use ($file) {
+                    return "<?php \$input = with(" . $expression . "); require '" . $file->getRealPath() . "'; ?>";
+                });
+            });
+
+            $directives->filter(function ($file) {
+                return ends_with($file->getFilename(), '.raw.php');
+            })->each(function ($file) use ($compiler) {
+                $compiler->directive($file->getBasename('.raw.php'), function ($expression) use ($file) {
+                    return require $file->getRealPath();
+                });
+            });
+        }
+
         return new CompilerEngine($compiler, new Filesystem);
     });
 

--- a/jigsaw
+++ b/jigsaw
@@ -45,7 +45,9 @@ $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath, $bl
                 return ends_with($file->getFilename(), '.php') && !ends_with($file->getFilename(), '.raw.php');
             })->each(function ($file) use ($compiler) {
                 $compiler->directive($file->getBasename('.php'), function ($expression) use ($file) {
-                    return "<?php \$input = with(" . $expression . "); require '" . $file->getRealPath() . "'; ?>";
+                    return "<?php execute_custom_blade_directive('" . $file->getRealPath() . "'" .
+                    ((trim($expression) != '') ? ", " . $expression : '') .
+                    "); ?>";
                 });
             });
 

--- a/jigsaw
+++ b/jigsaw
@@ -45,7 +45,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath, $sourcePath, $bl
                 return ends_with($file->getFilename(), '.php') && !ends_with($file->getFilename(), '.raw.php');
             })->each(function ($file) use ($compiler) {
                 $compiler->directive($file->getBasename('.php'), function ($expression) use ($file) {
-                    return "<?php execute_custom_blade_directive('" . $file->getRealPath() . "'" .
+                    return "<?php execute_custom_blade_directive('" . $file->getRealPath() . "', get_defined_vars()" .
                     ((trim($expression) != '') ? ", " . $expression : '') .
                     "); ?>";
                 });

--- a/jigsaw
+++ b/jigsaw
@@ -76,6 +76,8 @@ $container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {
     return new MarkdownHandler($tempFilesystem, $c[Factory::class]);
 });
 
+Container::setInstance($container);
+
 $jigsaw = new Jigsaw(new Filesystem, $cachePath);
 
 $jigsaw->registerHandler($container[MarkdownHandler::class]);

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -41,3 +41,16 @@ if (! function_exists('elixir')) {
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");
     }
 }
+
+if (! function_exists('execute_custom_blade_directive')) {
+    /**
+     * Execute custom blade directive in view file
+     *
+     * @param string $blade_file Directive file path
+     * @param null|string $input Input parameters
+     */
+    function execute_custom_blade_directive($blade_file, $input = null)
+    {
+        require $blade_file;
+    }
+}

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -47,9 +47,10 @@ if (! function_exists('execute_custom_blade_directive')) {
      * Execute custom blade directive in view file
      *
      * @param string $blade_file Directive file path
+     * @param array $parameters View variables
      * @param null|string $input Input parameters
      */
-    function execute_custom_blade_directive($blade_file, $input = null)
+    function execute_custom_blade_directive($blade_file, $parameters, $input = null)
     {
         require $blade_file;
     }


### PR DESCRIPTION
Referencing issue #20.

To register a custom blade directive you just create a file in the `/blade` directory, if you create `/blade/datetime.php` it will register the `@datetime` blade directive.

There's an important difference from Laravel's way of registering directives. The default way doesn't needs you to return the php code to put in your compiled view.
## Simple Directive (Default)

Example:

``` php
// File: /blade/datetime.php

/** @var $input mixed */
/** @var $parameters array */

echo date('Y-m-d H:i:s', $input);
```

This php file will be executed at runtime, receiving the evaluated object as `$input`. I found myself not needing to specify anything more complex then this in the majority of cases.

`$parameters` will be an array of current views parameters, which allows you to act based on configurations variables like `if ($parameters['production']) ...`.

The directive file has its own variable scope, which means it's possible to create and manipulate any variable without interfering with view's variables.
## Advanced Directive (Laravel Style)

If you need to work with the input expression (like Laravel's [extending feature](https://laravel.com/docs/5.3/blade#extending-blade)), you easily can just by naming the file `.raw.php`.

To replicate the datetime example in the previous step, you can do something like this:

``` php
// File: datetime.raw.php

/** @var $expression string */

return '<?php echo date("Y-m-d H:i:s", ' . $expression . '); ?>';
```

I've registered the service container using `Container::setInstance($container);` so that people can get the instance from their blade files. In the future they might be able to bind their own object in the service container.
