### PR TITLE
Customizing Parsedown

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -8,6 +8,9 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
+use Mni\FrontYAML\Markdown\MarkdownParser;
+use Mni\FrontYAML\Parser;
+use Mni\FrontYAML\YAML\YAMLParser;
 use TightenCo\Jigsaw\Console\BuildCommand;
 use TightenCo\Jigsaw\Console\InitCommand;
 use TightenCo\Jigsaw\Console\ServeCommand;
@@ -47,9 +50,15 @@ $container->bind(BladeHandler::class, function ($c) {
     return new BladeHandler($c[Factory::class]);
 });
 
+$container->bind(MarkdownParser::class, \Mni\FrontYAML\Bridge\Parsedown\ParsedownParser::class);
+$container->bind(YAMLParser::class, \Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser::class);
+$container->bind(Parser::class, function ($c) {
+    return new Parser($c[YAMLParser::class], $c[MarkdownParser::class], '---', '---');
+});
+
 $container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {
     $tempFilesystem = new TemporaryFilesystem($cachePath);
-    return new MarkdownHandler($tempFilesystem, $c[Factory::class]);
+    return new MarkdownHandler($tempFilesystem, $c[Factory::class], $c[Parser::class]);
 });
 
 $jigsaw = new Jigsaw(new Filesystem, $cachePath);

--- a/jigsaw
+++ b/jigsaw
@@ -8,6 +8,8 @@ use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
+use Mni\FrontYAML\Bridge\Parsedown\ParsedownParser;
+use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use Mni\FrontYAML\Parser;
 use Mni\FrontYAML\YAML\YAMLParser;
@@ -51,10 +53,10 @@ $container->bind(BladeHandler::class, function ($c) {
     return new BladeHandler($c[Factory::class]);
 });
 
-$container->bind(MarkdownParser::class, \Mni\FrontYAML\Bridge\Parsedown\ParsedownParser::class);
-$container->bind(YAMLParser::class, \Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser::class);
+$container->bind(MarkdownParser::class, ParsedownParser::class);
+$container->bind(YAMLParser::class, SymfonyYAMLParser::class);
 $container->bind(Parser::class, function ($c) {
-    return new Parser($c[YAMLParser::class], $c[MarkdownParser::class], '---', '---');
+    return new Parser($c[YAMLParser::class], $c[MarkdownParser::class]);
 });
 
 $container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {

--- a/jigsaw
+++ b/jigsaw
@@ -31,6 +31,7 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
 $cachePath = getcwd() . '/_tmp';
 $buildPath = getcwd() . '/build';
 $sourcePath = getcwd() . '/source';
+$bootstrapFile = getcwd() . '/bootstrap.php';
 
 $container = new Container;
 
@@ -62,6 +63,10 @@ $container->bind(MarkdownHandler::class, function ($c) use ($cachePath) {
 });
 
 $jigsaw = new Jigsaw(new Filesystem, $cachePath);
+
+if (file_exists($bootstrapFile)) {
+    require $bootstrapFile;
+}
 
 $jigsaw->registerHandler($container[MarkdownHandler::class]);
 $jigsaw->registerHandler($container[BladeHandler::class]);

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+/** @var $container \Illuminate\Container\Container */
+/** @var $jigsaw \TightenCo\Jigsaw\Jigsaw */


### PR DESCRIPTION
Referencing issue #64.

Placing a `bootstrap.php` file on the root of your jigsaw will load it before registering all file handlers.
The markdown and yaml parsers are resolved using the service container so you can re-bind them and extend parsedown.

## Example

Files to make the [inline colored text](https://github.com/erusev/parsedown/wiki/Tutorial:-Create-Extensions) in the parsedown wiki.

```php
<?php
// File: /bootstrap.php

use App\UberParsedown;
use Mni\FrontYAML\Markdown\MarkdownParser;

/** @var $container \Illuminate\Container\Container */
/** @var $jigsaw \TightenCo\Jigsaw\Jigsaw */

$container->bind(MarkdownParser::class, UberParsedown::class);
```

```php
<?php
// File: /app/UberParsedown.php

namespace App;

use Mni\FrontYAML\Markdown\MarkdownParser;
use Parsedown;

class UberParsedown extends Parsedown implements MarkdownParser
{
    function __construct()
    {
        $this->InlineTypes['{'] [] = 'ColoredText';

        $this->inlineMarkerList .= '{';
    }

    protected function inlineColoredText($Excerpt)
    {
        if (preg_match('/^{c:([#\w]\w+)}(.*?){\/c}/', $Excerpt['text'], $matches)) {
            return array(
                'extent' => strlen($matches[0]),
                'element' => array(
                    'name' => 'span',
                    'text' => $matches[2],
                    'attributes' => array(
                        'style' => 'color: ' . $matches[1],
                    ),
                ),
            );
        }

        return null;
    }
}
```

Now your markdown file:
```markdown
---
extends: _layouts.test_layout
section: content
---

# My awesome heading!

{c:#FFF}My awesome content!{/c}
```

Will be rendered as:
```html
<h1>My awesome heading!</h1>
<p><span style="color: #FFF">My awesome content!</span></p>
```

This has the side-effect to allow any further customization, like registering custom JigSaw handlers.