### PR TITLE
Bumping illuminate dependencies to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         ]
     },
     "require": {
-        "illuminate/container": "^5.2",
-        "illuminate/support": "^5.2",
-        "illuminate/view": "^5.2",
+        "illuminate/container": "^5.3",
+        "illuminate/support": "^5.3",
+        "illuminate/view": "^5.3",
         "symfony/console": "^2.5|^3.0",
         "mockery/mockery": "^0.9.4",
         "mnapoli/front-yaml": "^1.5"


### PR DESCRIPTION
I was unable to install jigsaw globally alongside laravel 5.3.
