### PR TITLE
Ability to get Collection object from CollectionItem object

### DIFF
--- a/src/Collection/CollectionItem.php
+++ b/src/Collection/CollectionItem.php
@@ -16,6 +16,11 @@ class CollectionItem extends IterableObject
 
         return $item;
     }
+    
+    public function getCollection()
+    {
+        return $this->collection;
+    }
 
     public function getHelper($name)
     {


### PR DESCRIPTION
When re-using templates for multiple collections, and you don't know the variable name of the collection (which I suppose is itself might be a trick to document?), this lets you get access to the collection from an `$item`.

I used this so I could `$item->getCollection()->getPermalink()` to create a link back to the "root" of the collection (e.g. blog listing page). For next/back links, `$item->getNext()`, etc, were sufficient, but this may let us do more tricks with collections for more custom uses.