### PR TITLE
Allow gulp command to check which jigsaw binary to use

### DIFF
--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var elixir = require('laravel-elixir');
 var argv = require('yargs').argv;
+var fs = require('fs')
 
 elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
@@ -8,9 +9,15 @@ elixir.config.publicPath = 'source';
 elixir(function(mix) {
     var env = argv.e || argv.env || 'local';
     var port = argv.p || argv.port || 3000;
+    var bin = fs.existsSync('jigsaw') || fs.existsSync('./vendor/bin/jigsaw');
+
+    if (!bin) {
+        console.log('Please, install jigsaw either globally or locally');
+	process.exit()
+    }
 
     mix.sass('main.scss')
-        .exec('jigsaw build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec(bin + ' build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
             port: port,
             server: { baseDir: 'build_' + env },

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var elixir = require('laravel-elixir');
 var argv = require('yargs').argv;
-var fs = require('fs')
+var bin = require('./tasks/bin');
 
 elixir.config.assetsPath = 'source/_assets';
 elixir.config.publicPath = 'source';
@@ -9,15 +9,9 @@ elixir.config.publicPath = 'source';
 elixir(function(mix) {
     var env = argv.e || argv.env || 'local';
     var port = argv.p || argv.port || 3000;
-    var bin = fs.existsSync('jigsaw') || fs.existsSync('./vendor/bin/jigsaw');
-
-    if (!bin) {
-        console.log('Please, install jigsaw either globally or locally');
-	process.exit()
-    }
 
     mix.sass('main.scss')
-        .exec(bin + ' build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec(bin.path() + ' build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
         .browserSync({
             port: port,
             server: { baseDir: 'build_' + env },
@@ -25,3 +19,4 @@ elixir(function(mix) {
             files: [ 'build_' + env + '/**/*' ]
         });
 });
+

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "fs": "0.0.1-security",
     "gulp": "^3.8.8",
     "hasbin": "^1.2.3",
     "laravel-elixir": "^4.2.0",

--- a/site/package.json
+++ b/site/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "fs": "0.0.1-security",
     "gulp": "^3.8.8",
+    "hasbin": "^1.2.3",
     "laravel-elixir": "^4.2.0",
     "yargs": "^4.6.0"
   }

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "devDependencies": {
+    "fs": "0.0.1-security",
     "gulp": "^3.8.8",
     "laravel-elixir": "^4.2.0",
     "yargs": "^4.6.0"

--- a/site/tasks/bin.js
+++ b/site/tasks/bin.js
@@ -1,0 +1,18 @@
+var hasbin = require('hasbin');
+var fs = require('fs');
+
+module.exports = { 
+    path: function() {
+        if (fs.existsSync('./vendor/bin/jigsaw')) {
+            return './vendor/bin/jigsaw'
+        }
+
+        if (hasbin.sync('jigsaw')) {
+            return 'jigsaw'; 
+        }
+        
+        console.log('Could not find Jigsaw; please install it via Composer, either locally or globally.');
+        
+        process.exit();
+    }
+};


### PR DESCRIPTION
When running gulp, instead of making the user change the gulp file, manually,
add a check for which jigsaw binary to use (global or local under vendor
folder) and in the case none exists prints a message to stdout via
console.log and exits the process.