### PR TITLE
Ignore folders and files generated for elixir versioning/cache busting

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,3 +1,6 @@
 /build_local/
 /node_modules/
 /vendor/
+/source/build
+/source/css
+/source/js

--- a/site/gulpfile.js
+++ b/site/gulpfile.js
@@ -11,7 +11,7 @@ elixir(function(mix) {
     var port = argv.p || argv.port || 3000;
 
     mix.sass('main.scss')
-        .exec(bin.path() + ' build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*'])
+        .exec(bin.path() + ' build ' + env, ['./source/*', './source/**/*', '!./source/_assets/**/*', '!./source/build/**/*'])
         .browserSync({
             port: port,
             server: { baseDir: 'build_' + env },


### PR DESCRIPTION
When using Elixir's ability to version/cache bust assets, it generates
folders and files inside `source` making `jigsaw` check its content
to generate HTML files.

By excluding those folders from jigsaw command, we avoid unnecessary
work. By also adding them to `.gitignore` we don't pollute the repo
versioning with generated files that will be sent to `build_<env>`
in the end.

For further infor on Elixir's versioning/cache busting functionality
we can refer to [Elixir's documentation](https://laravel.com/docs/5.3/elixir#versioning-and-cache-busting)