### PR TITLE
Pagination per page default option on config file

### DIFF
--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -36,7 +36,7 @@ class PaginatedPageHandler
 
         return $this->paginator->paginate($file,
             $pageData->get($pageData->page->pagination->collection),
-            $pageData->page->pagination->perPage ?: ($pageData->page->default_perPage ?: 1)
+            $pageData->page->pagination->perPage ?: ($pageData->page->perPage ?: 10)
         )->map(function ($page) use ($file, $pageData) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -36,7 +36,7 @@ class PaginatedPageHandler
 
         return $this->paginator->paginate($file,
             $pageData->get($pageData->page->pagination->collection),
-            $pageData->page->pagination->perPage ?: 10
+            $pageData->page->pagination->perPage ?: ($pageData->page->default_perPage ?: 1)
         )->map(function ($page) use ($file, $pageData) {
             $pageData->setPagePath($page->current);
             $pageData->put('pagination', $page);


### PR DESCRIPTION
### Added default_perPage option on config.php

This option allows the user to control the pagination globally on site.
Avoiding the default 10 items per page.