### PR TITLE
Adding permalink option on page data

### DIFF
--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -98,11 +98,23 @@ class SiteBuilder
 
     private function getOutputDirectory($file)
     {
+        if( $permalink = $this->getFilePermalink($file) ) {
+            return urldecode(dirname($permalink));
+        }
+
         return urldecode($this->outputPathResolver->directory($file->path(), $file->name(), $file->extension(), $file->page()));
     }
 
     private function getOutputPath($file)
     {
+        if( $permalink = $this->getFilePermalink($file) ) {
+            return urldecode($permalink);
+        }
+
         return urldecode($this->outputPathResolver->path($file->path(), $file->name(), $file->extension(), $file->page()));
+    }
+
+    private function getFilePermalink($file) {
+        return $file->data()->page->permalink ?: NULL;
     }
 }


### PR DESCRIPTION
That feature allows user to set a `permalink` key in the page's YAML front matter.

> 404.blade.md
``` markdown
---
extends: _layouts.master
title: "404 Error"
permalink: 404.html
section: body
---

### Oops! Maybe you did lost your path.
```

This configuration will change the default output from `404/index.html` to permalink's destination: `404.html`.
