### PR TITLE
Add ability to register custom blade tags

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -14,6 +14,7 @@ use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use Mni\FrontYAML\Parser;
 use Mni\FrontYAML\YAML\YAMLParser;
+use TightenCo\Jigsaw\BladeFile;
 use TightenCo\Jigsaw\CollectionDataLoader;
 use TightenCo\Jigsaw\CollectionItemHandlers\BladeCollectionItemHandler;
 use TightenCo\Jigsaw\CollectionItemHandlers\MarkdownCollectionItemHandler;
@@ -97,6 +98,8 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
     $resolver->register('blade-markdown', function () use ($c, $compilerEngine) {
         return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
+
+    (new BladeFile(getcwd() . '/blade.php'))->register($bladeCompiler);
 
     $finder = new FileViewFinder(new Filesystem, [$c['buildPath']['source']]);
 

--- a/jigsaw
+++ b/jigsaw
@@ -14,7 +14,7 @@ use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use Mni\FrontYAML\Parser;
 use Mni\FrontYAML\YAML\YAMLParser;
-use TightenCo\Jigsaw\BladeFile;
+use TightenCo\Jigsaw\BladeDirectivesFile;
 use TightenCo\Jigsaw\CollectionDataLoader;
 use TightenCo\Jigsaw\CollectionItemHandlers\BladeCollectionItemHandler;
 use TightenCo\Jigsaw\CollectionItemHandlers\MarkdownCollectionItemHandler;
@@ -99,7 +99,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
         return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
 
-    (new BladeFile(getcwd() . '/blade.php'))->register($bladeCompiler);
+    (new BladeDirectivesFile(getcwd() . '/blade.php'))->register($bladeCompiler);
 
     $finder = new FileViewFinder(new Filesystem, [$c['buildPath']['source']]);
 

--- a/src/BladeDirectivesFile.php
+++ b/src/BladeDirectivesFile.php
@@ -2,7 +2,7 @@
 
 use Illuminate\View\Compilers\BladeCompiler;
 
-class BladeFile
+class BladeDirectivesFile
 {
     protected $directives;
 

--- a/src/BladeFile.php
+++ b/src/BladeFile.php
@@ -1,0 +1,20 @@
+<?php namespace TightenCo\Jigsaw;
+
+use Illuminate\View\Compilers\BladeCompiler;
+
+class BladeFile
+{
+    protected $directives;
+
+    public function __construct($file_path)
+    {
+        $this->directives = file_exists($file_path) ? include $file_path : [];
+    }
+
+    public function register(BladeCompiler $compiler)
+    {
+        collect($this->directives)->each(function ($callback, $directive) use ($compiler) {
+            $compiler->directive($directive, $callback);
+        });
+    }
+}


### PR DESCRIPTION
See #67.

To register a blade directive:
```php
<php
// blade.php

return [
    'datetime' => function ($expression) {
      return '<?php echo date("Y-m-d H:i:s", ' . $expression . '); ?>';
    }
];
```

I didn't add the $page parameter because it was calculated using get_defined_vars() on the resolved blade instance.