### PR TITLE
Copy files without an extension properly

### DIFF
--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -34,6 +34,10 @@ class PrettyOutputPathResolver
             return $this->trimPath($path) . '/' . $name . '/' . 'index.html';
         }
 
+        if (empty($type)) {
+            return sprintf('%s%s%s', $this->trimPath($path), '/', $name);
+        }
+
         return sprintf('%s%s%s.%s', $this->trimPath($path), '/', $name, $type);
     }
 


### PR DESCRIPTION
When I tried to publish my Jigsaw site with Github Pages, I noticed that `jigsaw build production` copied the `CNAME` file over incorrectly from `source/` with a trailing `.` character.

![screen shot 2017-04-23 at 12 43 04 am](https://cloud.githubusercontent.com/assets/177773/25311788/bded43c4-27be-11e7-873a-6236db72271a.png)

I added a check for an empty `$type` and returns the path without the `.` in the file.