### PR TITLE
Fix pagination bug on home page

### DIFF
--- a/src/Collection/CollectionPaginator.php
+++ b/src/Collection/CollectionPaginator.php
@@ -39,11 +39,12 @@ class CollectionPaginator
 
     private function getPageLink($file, $pageNumber)
     {
-        return rtrim($this->outputPathResolver->link(
+        $link = $this->outputPathResolver->link(
             $file->getRelativePath(),
             $file->getFilenameWithoutExtension(),
             'html',
             $pageNumber
-        ), '/');
+        );
+        return ($link !== '/') ? rtrim($link, '/') : $link;
     }
 }


### PR DESCRIPTION
Safety check before rtrim() call in order to support pagination on source/index.blade.php

When using pagination on the home page `source/index.blade.php`, the call to `$pagination->previous` when on the _second_ page returns `null`.

I believe the issue lies withing `TightenCo\Jigsaw\Collection\ CollectionPaginator:: getPageLink()` that performs a `return rtrim($this->outputPathResolver->link(...), '/');` 