### PR TITLE
Normalize the local jigsaw path call for Windows

### DIFF
--- a/site/tasks/bin.js
+++ b/site/tasks/bin.js
@@ -1,10 +1,11 @@
 var hasbin = require('hasbin');
 var fs = require('fs');
+var path = require('path');
 
 module.exports = {
     path: function() {
         if (fs.existsSync('./vendor/bin/jigsaw')) {
-            return '"./vendor/bin/jigsaw"'
+            return path.normalize('./vendor/bin/jigsaw')
         }
 
         if (hasbin.sync('jigsaw')) {

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -13,14 +13,14 @@ class InputFile
 
     public function topLevelDirectory()
     {
-        $parts = explode('/', $this->relativePath());
+        $parts = preg_split('/[\\/\\\]+/', $this->relativePath());
 
         return count($parts) == 1 ? '' : $parts[0];
     }
 
     public function relativePath()
     {
-        return str_replace($this->basePath . '/', '', $this->file->getPathname());
+        return trim(str_replace($this->basePath, '', $this->file->getPathname()), "\\/");
     }
 
     public function bladeViewPath()


### PR DESCRIPTION
@damiani when runnign on Windows 10, I found running the local jigsaw from the vendor directory would crap out:

```
'.' is not recognized as an internal or external command,
operable program or batch file.
```

I implemented these changes as I was debugging and reusing the pull request here: https://github.com/tightenco/jigsaw/pull/126, which i needed in order to proceed with my development.

Thanks for your work here!
Adam