### PR TITLE
Add Multiple Site Support

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -103,11 +103,11 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
 
     $finder = new FileViewFinder(new Filesystem, [$c['buildPath']['source']]);
 
-	  if(isset($c['config']['modules'])) {
-		    foreach($c['config']['modules'] as $namespace => $path) {
-			      $finder->addNamespace($namespace, $path);
-		    }
-	  }
+    if(isset($c['config']['modules'])) {
+        foreach($c['config']['modules'] as $namespace => $path) {
+            $finder->addNamespace($namespace, $path);
+        }
+    }
 
     return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });

--- a/jigsaw
+++ b/jigsaw
@@ -103,11 +103,11 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
 
     $finder = new FileViewFinder(new Filesystem, [$c['buildPath']['source']]);
 
-	if(isset($c['config']['modules'])) {
-		foreach($c['config']['modules'] as $namespace => $path) {
-			$finder->addNamespace($namespace, $path);
-		}
-	}
+	  if(isset($c['config']['modules'])) {
+		    foreach($c['config']['modules'] as $namespace => $path) {
+			      $finder->addNamespace($namespace, $path);
+		    }
+	  }
 
     return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });

--- a/jigsaw
+++ b/jigsaw
@@ -103,6 +103,12 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
 
     $finder = new FileViewFinder(new Filesystem, [$c['buildPath']['source']]);
 
+	if(isset($c['config']['modules'])) {
+		foreach($c['config']['modules'] as $namespace => $path) {
+			$finder->addNamespace($namespace, $path);
+		}
+	}
+
     return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
 });
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use TightenCo\Jigsaw\ConfigFile;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\PathResolvers\PrettyOutputPathResolver;
 
@@ -20,6 +21,7 @@ class BuildCommand extends Command
         $this->setName('build')
             ->setDescription('Build your site.')
             ->addArgument('env', InputArgument::OPTIONAL, "What environment should we use to build?", 'local')
+			->addOption('site', 's', InputOption::VALUE_OPTIONAL, "Build a specific site.", null)
             ->addOption('pretty', null, InputOption::VALUE_REQUIRED, "Should the site use pretty URLs?", 'true');
     }
 
@@ -27,15 +29,47 @@ class BuildCommand extends Command
     {
         $env = $this->input->getArgument('env');
         $this->includeEnvironmentConfig($env);
-        $this->updateBuildPaths($env);
 
         if ($this->input->getOption('pretty') === 'true') {
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
         }
 
-        $this->app->make(Jigsaw::class)->build($env);
-        $this->info('Site built successfully!');
+        if(!$this->app->config->has('sites')) {
+        	$this->buildSite($env);
+        	return;
+		}
+
+		$site = $this->input->getOption('site');
+
+        if(!empty($site)) {
+			if(!array_key_exists($site, $this->app->config['sites'])) {
+				$this->error("The site {$site} was not found in the config file's sites array.");
+				return;
+			}
+
+        	$this->buildSite($env, $site, $this->app->config['sites'][$site]);
+        	return;
+		}
+
+		$sites = $this->app->config['sites'];
+		foreach($sites as $name => $source) {
+			$this->buildSite($env, $name, $source);
+		}
     }
+
+    private function buildSite($env, $site = null, $source = null) {
+		if(!empty($site)) {
+			$config = (new ConfigFile($this->getAbsolutePath($source.'/config.php')))->config;
+			$config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
+			$this->app->instance('config', collect($config));
+		} else {
+			$site = 'Site';
+		}
+
+		$this->updateBuildPaths($env);
+    	$this->app->make(Jigsaw::class)->build($env);
+    	$this->info("{$site} built successfully.");
+	}
 
     private function includeEnvironmentConfig($env)
     {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -21,7 +21,7 @@ class BuildCommand extends Command
         $this->setName('build')
             ->setDescription('Build your site.')
             ->addArgument('env', InputArgument::OPTIONAL, "What environment should we use to build?", 'local')
-			      ->addOption('site', 's', InputOption::VALUE_OPTIONAL, "Build a specific site.", null)
+            ->addOption('site', 's', InputOption::VALUE_OPTIONAL, "Build a specific site.", null)
             ->addOption('pretty', null, InputOption::VALUE_REQUIRED, "Should the site use pretty URLs?", 'true');
     }
 
@@ -35,42 +35,42 @@ class BuildCommand extends Command
         }
 
         if(!$this->app->config->has('sites')) {
-        	  $this->buildSite($env);
-        	  return;
-		    }
+            $this->buildSite($env);
+            return;
+        }
 
-		    $site = $this->input->getOption('site');
+        $site = $this->input->getOption('site');
 
         if(!empty($site)) {
-			      if(!array_key_exists($site, $this->app->config['sites'])) {
-				        $this->error("The site {$site} was not found in the config file's sites array.");
-				        return;
-			      }
+            if(!array_key_exists($site, $this->app->config['sites'])) {
+                $this->error("The site {$site} was not found in the config file's sites array.");
+                return;
+            }
 
-        	  $this->buildSite($env, $site, $this->app->config['sites'][$site]);
-        	  return;
-		    }
+            $this->buildSite($env, $site, $this->app->config['sites'][$site]);
+            return;
+        }
 
-		    $sites = $this->app->config['sites'];
-		    foreach($sites as $name => $source) {
-			      $this->buildSite($env, $name, $source);
-		    }
+        $sites = $this->app->config['sites'];
+        foreach($sites as $name => $source) {
+            $this->buildSite($env, $name, $source);
+        }
     }
 
     private function buildSite($env, $site = null, $source = null)
     {
-		    if(!empty($site)) {
-			      $config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
-			      $config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
-			      $this->app->instance('config', collect($config));
-		    } else {
-			      $site = 'Site';
-		    }
+        if(!empty($site)) {
+            $config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
+            $config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
+            $this->app->instance('config', collect($config));
+        } else {
+            $site = 'Site';
+        }
 
-		    $this->updateBuildPaths($env);
-    	  $this->app->make(Jigsaw::class)->build($env);
-    	  $this->info("{$site} built successfully.");
-	  }
+        $this->updateBuildPaths($env);
+        $this->app->make(Jigsaw::class)->build($env);
+        $this->info("{$site} built successfully.");
+    }
 
     private function includeEnvironmentConfig($env)
     {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -34,9 +34,9 @@ class BuildCommand extends Command
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
         }
 
-		if($this->app->config->has('modules')) {
-			$this->modules = $this->app->config->get('modules');
-		}
+        if($this->app->config->has('modules')) {
+            $this->modules = $this->app->config->get('modules');
+        }
 
         if(!$this->app->config->has('sites')) {
             $this->buildSite($env);

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -21,7 +21,7 @@ class BuildCommand extends Command
         $this->setName('build')
             ->setDescription('Build your site.')
             ->addArgument('env', InputArgument::OPTIONAL, "What environment should we use to build?", 'local')
-			->addOption('site', 's', InputOption::VALUE_OPTIONAL, "Build a specific site.", null)
+			      ->addOption('site', 's', InputOption::VALUE_OPTIONAL, "Build a specific site.", null)
             ->addOption('pretty', null, InputOption::VALUE_REQUIRED, "Should the site use pretty URLs?", 'true');
     }
 
@@ -35,41 +35,42 @@ class BuildCommand extends Command
         }
 
         if(!$this->app->config->has('sites')) {
-        	$this->buildSite($env);
-        	return;
-		}
+        	  $this->buildSite($env);
+        	  return;
+		    }
 
-		$site = $this->input->getOption('site');
+		    $site = $this->input->getOption('site');
 
         if(!empty($site)) {
-			if(!array_key_exists($site, $this->app->config['sites'])) {
-				$this->error("The site {$site} was not found in the config file's sites array.");
-				return;
-			}
+			      if(!array_key_exists($site, $this->app->config['sites'])) {
+				        $this->error("The site {$site} was not found in the config file's sites array.");
+				        return;
+			      }
 
-        	$this->buildSite($env, $site, $this->app->config['sites'][$site]);
-        	return;
-		}
+        	  $this->buildSite($env, $site, $this->app->config['sites'][$site]);
+        	  return;
+		    }
 
-		$sites = $this->app->config['sites'];
-		foreach($sites as $name => $source) {
-			$this->buildSite($env, $name, $source);
-		}
+		    $sites = $this->app->config['sites'];
+		    foreach($sites as $name => $source) {
+			      $this->buildSite($env, $name, $source);
+		    }
     }
 
-    private function buildSite($env, $site = null, $source = null) {
-		if(!empty($site)) {
-			$config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
-			$config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
-			$this->app->instance('config', collect($config));
-		} else {
-			$site = 'Site';
-		}
+    private function buildSite($env, $site = null, $source = null)
+    {
+		    if(!empty($site)) {
+			      $config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
+			      $config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
+			      $this->app->instance('config', collect($config));
+		    } else {
+			      $site = 'Site';
+		    }
 
-		$this->updateBuildPaths($env);
-    	$this->app->make(Jigsaw::class)->build($env);
-    	$this->info("{$site} built successfully.");
-	}
+		    $this->updateBuildPaths($env);
+    	  $this->app->make(Jigsaw::class)->build($env);
+    	  $this->info("{$site} built successfully.");
+	  }
 
     private function includeEnvironmentConfig($env)
     {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -59,7 +59,7 @@ class BuildCommand extends Command
 
     private function buildSite($env, $site = null, $source = null) {
 		if(!empty($site)) {
-			$config = (new ConfigFile($this->getAbsolutePath($source.'/config.php')))->config;
+			$config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
 			$config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
 			$this->app->instance('config', collect($config));
 		} else {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -8,7 +8,7 @@ use TightenCo\Jigsaw\PathResolvers\PrettyOutputPathResolver;
 
 class BuildCommand extends Command
 {
-    private $app;
+    private $app, $modules = [];
 
     public function __construct($app)
     {
@@ -33,6 +33,10 @@ class BuildCommand extends Command
         if ($this->input->getOption('pretty') === 'true') {
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
         }
+
+		if($this->app->config->has('modules')) {
+			$this->modules = $this->app->config->get('modules');
+		}
 
         if(!$this->app->config->has('sites')) {
             $this->buildSite($env);
@@ -62,6 +66,7 @@ class BuildCommand extends Command
         if(!empty($site)) {
             $config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
             $config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
+            $config['modules'] = $this->modules;
             $this->app->instance('config', collect($config));
         } else {
             $site = 'Site';
@@ -69,7 +74,7 @@ class BuildCommand extends Command
 
         $this->updateBuildPaths($env);
         $this->app->make(Jigsaw::class)->build($env);
-        $this->info("{$site} built successfully.");
+        $this->info("{$site} built successfully!");
     }
 
     private function includeEnvironmentConfig($env)

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -64,8 +64,14 @@ class BuildCommand extends Command
     private function buildSite($env, $site = null, $source = null)
     {
         if(!empty($site)) {
+        	// If the config.php has a sites array, assume there is a "source" directory inside the site
+			// and if no destination is specified in the site's specific config.php, default to a new
+			// build_local/site_name directory to build into. This namespaces each site's build.
             $config = (new ConfigFile($this->getAbsolutePath($source.DIRECTORY_SEPARATOR.'config.php')))->config;
             $config['build']['source'] = $source.DIRECTORY_SEPARATOR.'source';
+			$config['build']['destination'] = array_has($config, 'build.destination')
+				? array_get($config, 'build.destination')
+				: 'build_local'.DIRECTORY_SEPARATOR.$site;
             $config['modules'] = $this->modules;
             $this->app->instance('config', collect($config));
         } else {

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -24,13 +24,13 @@ class ServeCommand extends Command
                 'What environment should we serve?',
                 'local'
             )
-			      ->addOption(
-				        'site',
-				        's',
-				        InputOption::VALUE_OPTIONAL,
-				        'What site should we use?',
-				        null
-			      )
+            ->addOption(
+                'site',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'What site should we use?',
+                null
+            )
             ->addOption(
                 'port',
                 'p',
@@ -52,18 +52,18 @@ class ServeCommand extends Command
 
     private function getSiteConfig($env)
     {
-    	  if(!isset($this->app->config['sites'])) {
-    		    return $this->getAbsolutePath("config.{$env}.php");
-		    }
+        if(!isset($this->app->config['sites'])) {
+            return $this->getAbsolutePath("config.{$env}.php");
+        }
 
-		    $site = $this->input->getOption('site');
-		    if(empty($site)) {
-			      $site = key($this->app->config['sites']);
-		    }
+        $site = $this->input->getOption('site');
+        if(empty($site)) {
+            $site = key($this->app->config['sites']);
+        }
 
-		    $config = $this->app->config['sites'][ $site ];
-		    return $this->getAbsolutePath($config.DIRECTORY_SEPARATOR."config.php");
-	  }
+        $config = $this->app->config['sites'][ $site ];
+        return $this->getAbsolutePath($config.DIRECTORY_SEPARATOR."config.php");
+    }
 
     private function getBuildPath($env)
     {

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -24,13 +24,13 @@ class ServeCommand extends Command
                 'What environment should we serve?',
                 'local'
             )
-			->addOption(
-				'site',
-				's',
-				InputOption::VALUE_OPTIONAL,
-				'What site should we use?',
-				null
-			)
+			      ->addOption(
+				        'site',
+				        's',
+				        InputOption::VALUE_OPTIONAL,
+				        'What site should we use?',
+				        null
+			      )
             ->addOption(
                 'port',
                 'p',
@@ -50,19 +50,20 @@ class ServeCommand extends Command
         passthru("php -S localhost:{$port} -t " . escapeshellarg($this->getBuildPath($env)));
     }
 
-    private function getSiteConfig($env) {
-    	if(!isset($this->app->config['sites'])) {
-    		return $this->getAbsolutePath("config.{$env}.php");
-		}
+    private function getSiteConfig($env)
+    {
+    	  if(!isset($this->app->config['sites'])) {
+    		    return $this->getAbsolutePath("config.{$env}.php");
+		    }
 
-		$site = $this->input->getOption('site');
-		if(empty($site)) {
-			$site = key($this->app->config['sites']);
-		}
+		    $site = $this->input->getOption('site');
+		    if(empty($site)) {
+			      $site = key($this->app->config['sites']);
+		    }
 
-		$config = $this->app->config['sites'][ $site ];
-		return $this->getAbsolutePath($config.DIRECTORY_SEPARATOR."config.php");
-	}
+		    $config = $this->app->config['sites'][ $site ];
+		    return $this->getAbsolutePath($config.DIRECTORY_SEPARATOR."config.php");
+	  }
 
     private function getBuildPath($env)
     {


### PR DESCRIPTION
This PR is in response to issue #128 and adds the following conventions to support multiple sites.

1. If the installation should support multiple sites, the **config.php** in the root directory should contain a "sites" array with the keys being the short name of the site, and the values being the site location.

```php
// in /config.php

"sites" => [
    'site-1' => 'site-1',
    'site-2' => 'some-directory/site-2'
]
```

2. The directory destination each site points to should include a **source** directory, and a **config.php** file specific to that site. Each site's config file can follow the normal Jigsaw standards and also specify a build destination. HOWEVER, be aware that all build destinations are in relation to the root directory because the current working directory is not changed.
```php
// Example directory structure
/config.php
/jigsaw
/site-1
    /config.php
    /source
        /index.php
        /css
        /js
/some-directory
    /site-2
        /config.php
        /source
            /index.php
            /css
            /js
```

3. In the root **config.php** a new "modules" directory can specify the locations of view modules. These follow the standard Laravel convention that allows blade files to use a short `::` syntax to specify resource locations.

```php
// In /config.php
"modules" => [
    'First' => 'path/to/first/module',
    'Second' => 'path/to/second/module'
]

// Somewhere in a view
@extends('First::_layouts.master')

// or
@include('Second::_partials.navigation')
```

4. In order to maintain backwards compatibility, the following conventions have been followed with terminal commands:
    - If no "sites" index exists in the root level **config.php** file, all commands act exactly as they have. If a "modules" index exists, modules are added whether or not a sites index exists.
    - If a "sites" index exists, the `build` command iterates through each site and builds each serially.
    - A specific site can be specified with the `--site="sitename"` option or it's `-s sitename` alias. Doing so causes only the specified site to build. I decided to make this an option rather than a required argument because until now the `env` has been the argument immediately following the `build` command.
    - If the `serve` command is used and a "sites" index exists in the main config, the first site in the array will be attempted.
    - A site can be specified for the `serve` command by specifying the `--site="sitename"` argument or `-s sitename`.
    - No matter which site is served, if the site has not been built, the standard warning is shown before the command exits.

### Further Ideas
Currently there is no way to share "collections" between sites. It would be nice to be able to specify a location in any one collection's config array so that in the same way this PR adds the ability to share resources, collections could share content. If this sounds like an interesting idea, I'll be building that for our own stuff here and can make another PR.