### PR TITLE
Dispatcher Event/Listener after build completed

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -37,8 +37,8 @@ class BuildCommand extends Command
 
         $this->app->make(Jigsaw::class)->build($env);
         /** @var $dispatcher Dispatcher */
-        $dispatcher = $this->app->make(Dispatcher::class);
-        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
+//        $dispatcher = $this->app->make(Dispatcher::class);
+//        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -37,8 +37,8 @@ class BuildCommand extends Command
 
         $this->app->make(Jigsaw::class)->build($env);
         /** @var $dispatcher Dispatcher */
-//        $dispatcher = $this->app->make(Dispatcher::class);
-//        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
+        $dispatcher = $this->app->make(Dispatcher::class);
+        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -38,7 +38,7 @@ class BuildCommand extends Command
         $this->app->make(Jigsaw::class)->build($env);
         /** @var $dispatcher Dispatcher */
         $dispatcher = $this->app->make(Dispatcher::class);
-        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
+        $dispatcher->fire(new BuildHasCompleted($this->app));
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1,7 +1,9 @@
 <?php namespace TightenCo\Jigsaw\Console;
 
+use Illuminate\Events\Dispatcher;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use TightenCo\Jigsaw\Events\BuildHasCompleted;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\PathResolvers\PrettyOutputPathResolver;
 
@@ -34,6 +36,9 @@ class BuildCommand extends Command
         }
 
         $this->app->make(Jigsaw::class)->build($env);
+        /** @var $dispatcher Dispatcher */
+        $dispatcher = $this->app->make(Dispatcher::class);
+        $dispatcher->fire(new BuildHasCompleted(Jigsaw::class));
         $this->info('Site built successfully!');
     }
 

--- a/src/Events/BuildHasCompleted.php
+++ b/src/Events/BuildHasCompleted.php
@@ -1,0 +1,15 @@
+<?php namespace TightenCo\Jigsaw\Events;
+
+
+use Illuminate\Container\Container;
+
+class BuildHasCompleted
+{
+    /** @var  $app Container */
+    protected $app;
+
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+}

--- a/src/Events/BuildHasCompleted.php
+++ b/src/Events/BuildHasCompleted.php
@@ -6,7 +6,7 @@ use Illuminate\Container\Container;
 class BuildHasCompleted
 {
     /** @var  $app Container */
-    protected $app;
+    public $app;
 
     public function __construct($app)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,7 @@ class TestCase extends BaseTestCase
     {
         parent::setUpBeforeClass();
 
-        echo shell_exec('./jigsaw build testing');
+        echo shell_exec('php ./jigsaw build testing');
     }
 
     public static function tearDownAfterClass()


### PR DESCRIPTION
Hey @damiani ,

I think I figured out a reasonable solution.  The idea here is we can implement Event classes based off the `Illuminate\Dispatcher`.  Then in the uses `bootstrap.php` they can hack in listeners as they so choose.

For example, my `bootstrap.php` for adding to Algolia is here:

```php
use Illuminate\Events\Dispatcher;
use TightenCo\Jigsaw\DataLoader;
use TightenCo\Jigsaw\Events\BuildHasCompleted;


$container->bind(Dispatcher::class, function ($c) {

    $dispatcher = new Dispatcher();

    $dispatcher->listen([BuildHasCompleted::class], function ($event) {
        $dotenv = new Dotenv\Dotenv(__DIR__);
        $dotenv->load();


        $client = new \AlgoliaSearch\Client(getenv('ALGOLIA_APP_ID'), getenv('ALGOLIA_ADMIN_API_KEY'));

        $index = $client->initIndex('prod_html');

        /** @var \TightenCo\Jigsaw\DataLoader $dataLoader */
        $dataLoader = $event->app->make(DataLoader::class);

        /** @var TightenCo\Jigsaw\Collection\Collection $siteData */
        $siteData = $dataLoader->load($event->app->buildPath['source'], $event->app->config);

        $siteDataArr = $siteData->toArray();

        $val = $index->addObjects($siteDataArr);

    });

    return $dispatcher;
});

```

Now, I know this is not the most elegant solution within the `bootstrap.php`.  I think the end goal here is to put the listeners into the `config.php` instead.  In fact, I still need to implement logic here that will only execute when the environment is  `production`.  In my example above, ignore the DotEnv stuff, I figured out that I can create a separate `config.production.php` for the Algolia API and SECRET keys. 

What I need to figure out how to do is wrap all this into a class.  Currently, this would mean i need to make a new composer.json entry that takes in psr-4 of the `source` directory and I put Listeners in there?  What would you recommend?

Cheers!
Adam