### PR TITLE
Allow .atom files

### DIFF
--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -12,7 +12,7 @@ class ViewRenderer
         'blade.markdown' => 'blade-markdown',
     ];
     private $bladeExtensions = [
-        'js', 'json', 'xml', 'rss', 'txt', 'text', 'html'
+        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html'
     ];
 
     public function __construct(Factory $viewFactory)


### PR DESCRIPTION
I use `.atom` files instead of `.rss`. Don't ask me why, but that's where my feed has been for ages, so I figured I'd try it out. :)