### PR TITLE
Fix sorting of collection items by multiple variables

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -68,19 +68,19 @@ class Collection extends BaseCollection
     private function compareItems($item_1, $item_2, $sortSettings)
     {
         foreach ($sortSettings as $setting) {
-            $comparison = $setting['direction'] * strcasecmp(
-                $this->getValueForSorting($item_1, array_get($setting, 'key')),
-                $this->getValueForSorting($item_2, array_get($setting, 'key'))
-            );
+            $value_1 = $this->getValueForSorting($item_1, array_get($setting, 'key'));
+            $value_2 = $this->getValueForSorting($item_2, array_get($setting, 'key'));
 
-            if ($comparison) {
-                return $comparison;
+            if ($value_1 > $value_2) {
+               return $setting['direction'];
+            } elseif ($value_1 < $value_2) {
+               return -$setting['direction'];
             }
         }
     }
 
     private function getValueForSorting($item, $key)
     {
-        return $item->$key instanceof Closure ? $item->$key($item) : $item->$key;
+        return strtolower($item->$key instanceof Closure ? $item->$key($item) : $item->$key);
     }
 }

--- a/tests/config.php
+++ b/tests/config.php
@@ -42,6 +42,9 @@ return [
         'collection_tests' => [
             'sum' => 99999,
         ],
+        'sort_tests' => [
+            'sort' => ['letter', '-number'],
+        ],
         'posts' => [
             'helperFunction' => function ($data) {
                 return 'hello from posts! #' . $data->number;

--- a/tests/snapshots/sort-test-multi/index.html
+++ b/tests/snapshots/sort-test-multi/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+    </head>
+    <body class="border-t-3 border-primary full-height">
+
+        <nav class="navbar navbar-brand">
+            <div class="container">
+                <div class="navbar-content">
+                    <div>
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                            <strong>Jigsaw Collections Demo</strong>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </nav>
+
+        <div class="container m-xs-b-6">
+            <div class="row">
+
+                <div class="col-xs-4">
+                    <nav class="nav-list">
+    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+        <icon></icon>Posts
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+        <icon></icon>Pagination
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+        <icon></icon>Categories
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+        <icon></icon>People
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+        <icon></icon>Variables
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+        <icon></icon>JSON
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+        <icon></icon>Text
+    </a>
+</nav>
+                    <div class="panel m-xs-t-6">
+    <div class="panel-heading">
+        <h4 class="text-sm wt-light text-uppercase text-brand">Page meta</h4>
+    </div>
+
+    <div class="panel-body">
+        <div class="p-xs-b-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Filename:</p>
+            <p class="p-xs-l-2 text-sm">sort-test-multi</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Extension:</p>
+            <p class="p-xs-l-2 text-sm">blade.php</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Path:</p>
+            <p class="p-xs-l-2 text-sm">/sort-test-multi</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/sort-test-multi</p>
+        </div>
+
+        <div class="p-xs-t-4">
+            <p class="text-xs text-dark-soft text-uppercase">Global Variable:</p>
+            <p class="p-xs-l-2 text-sm">some global variable</p>
+        </div>
+    </div>
+</div>
+                                    </div>
+
+                <div class="col-xs-8 demo-page">
+                    <h2>Multisort Test</h2>
+
+    <p>2-a</p>
+    <p>1-a</p>
+    <p>2-B</p>
+    <p>1-b</p>
+    <p>2-c</p>
+    <p>1-C</p>
+    <p>1-d</p>
+    <p>3-e</p>
+    <p>3-f</p>
+
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+<!DOCTYPE html>

--- a/tests/source/_sort_tests/sort-test-1-C.md
+++ b/tests/source/_sort_tests/sort-test-1-C.md
@@ -1,0 +1,5 @@
+---
+title: 1-C
+number: 1
+letter: C
+---

--- a/tests/source/_sort_tests/sort-test-1-a.md
+++ b/tests/source/_sort_tests/sort-test-1-a.md
@@ -1,0 +1,5 @@
+---
+title: 1-a
+number: 1
+letter: a
+---

--- a/tests/source/_sort_tests/sort-test-1-b.md
+++ b/tests/source/_sort_tests/sort-test-1-b.md
@@ -1,0 +1,5 @@
+---
+title: 1-b
+number: 1
+letter: b
+---

--- a/tests/source/_sort_tests/sort-test-1-d.md
+++ b/tests/source/_sort_tests/sort-test-1-d.md
@@ -1,0 +1,5 @@
+---
+title: 1-d
+number: 1
+letter: d
+---

--- a/tests/source/_sort_tests/sort-test-2-B.md
+++ b/tests/source/_sort_tests/sort-test-2-B.md
@@ -1,0 +1,5 @@
+---
+title: 2-B
+number: 2
+letter: B
+---

--- a/tests/source/_sort_tests/sort-test-2-a.md
+++ b/tests/source/_sort_tests/sort-test-2-a.md
@@ -1,0 +1,5 @@
+---
+title: 2-a
+number: 2
+letter: a
+---

--- a/tests/source/_sort_tests/sort-test-2-c.md
+++ b/tests/source/_sort_tests/sort-test-2-c.md
@@ -1,0 +1,5 @@
+---
+title: 2-c
+number: 2
+letter: c
+---

--- a/tests/source/_sort_tests/sort-test-3-e.md
+++ b/tests/source/_sort_tests/sort-test-3-e.md
@@ -1,0 +1,5 @@
+---
+title: 3-e
+number: 3
+letter: e
+---

--- a/tests/source/_sort_tests/sort-test-3-f.md
+++ b/tests/source/_sort_tests/sort-test-3-f.md
@@ -1,0 +1,5 @@
+---
+title: 3-f
+number: 3
+letter: f
+---

--- a/tests/source/sort-test-multi.blade.php
+++ b/tests/source/sort-test-multi.blade.php
@@ -1,0 +1,10 @@
+@extends('_layouts.master')
+
+@section('body')
+<h2>Multisort Test</h2>
+
+@foreach ($sort_tests as $item)
+    <p>{{ $item->number }}-{{ $item->letter }}</p>
+@endforeach
+
+@endsection


### PR DESCRIPTION
Fixes https://github.com/tightenco/jigsaw/issues/154

When working with collections, the `sort` parameter in `config.php` can accept an array of multiple values. This was previously done with chained calls to the Illuminate/Collection `sortBy` or `sortByDesc` methods, but that doesn't do what we expect; instead (as referenced in https://github.com/laravel/internals/issues/11), it does not maintain the order of any of the preliminary sorts, and in the end only sorts by the final `sortBy` clause.

This has been fixed by using the `sort` method, which calls PHP's `usort` under the hood and allows us to do our own comparison. I've used what I believe is a pretty elegant solution from https://stackoverflow.com/a/27364612/4043861, which makes the comparison between adjacent items by stepping through each criterion (each variable, in our case) and tests them with `strcmp()`, returning the first non-zero value from a nested ternary expression:

```php
$items->sort(
    function ($a, $b) {
        // sort by column1 first, then 2, and so on
        return strcmp($a->column1, $b->column1)
            ?: strcmp($a->column2, $b->column2)
            ?: strcmp($a->column3, $b->column3);
    }
);
```