### PR TITLE
Strip URL-invalid characters from path names

### DIFF
--- a/src/PathResolvers/CollectionPathResolver.php
+++ b/src/PathResolvers/CollectionPathResolver.php
@@ -89,7 +89,7 @@ class CollectionPathResolver
             $param = ltrim($param, $param[0]);
         }
 
-        $value = array_get($data, $param, $data->_meta->get($param));
+        $value = $this->filterInvalidCharacters(array_get($data, $param, $data->_meta->get($param)));
 
         if (! $value) {
             return '';
@@ -151,5 +151,13 @@ class CollectionPathResolver
         $string = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $string);
 
         return trim($string, $separator);
+    }
+
+    /**
+     * Filter characters that are invalid in URL, like ® and ™, allowing spaces
+     */
+    private function filterInvalidCharacters($value)
+    {
+        return is_string($value) ? preg_replace('/[^\x20-\x7E]/', '', $value) : $value;
     }
 }

--- a/tests/config.php
+++ b/tests/config.php
@@ -45,6 +45,9 @@ return [
         'sort_tests' => [
             'sort' => ['letter', '-number'],
         ],
+        'invalid_path_characters_test' => [
+            'path' => '{title}',
+        ],
         'posts' => [
             'helperFunction' => function ($data) {
                 return 'hello from posts! #' . $data->number;

--- a/tests/snapshots/Remove Invalid Characters, from Paths?!/index.html
+++ b/tests/snapshots/Remove Invalid Characters, from Paths?!/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+    </head>
+    <body class="border-t-3 border-primary full-height">
+
+        <nav class="navbar navbar-brand">
+            <div class="container">
+                <div class="navbar-content">
+                    <div>
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                            <strong>Jigsaw Collections Demo</strong>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </nav>
+
+        <div class="container m-xs-b-6">
+            <div class="row">
+
+                <div class="col-xs-4">
+                    <nav class="nav-list">
+    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+        <icon></icon>Posts
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+        <icon></icon>Pagination
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+        <icon></icon>Categories
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+        <icon></icon>People
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+        <icon></icon>Variables
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+        <icon></icon>JSON
+    </a>
+
+    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+        <icon></icon>Text
+    </a>
+</nav>
+                    <div class="panel m-xs-t-6">
+    <div class="panel-heading">
+        <h4 class="text-sm wt-light text-uppercase text-brand">Page meta</h4>
+    </div>
+
+    <div class="panel-body">
+        <div class="p-xs-b-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Filename:</p>
+            <p class="p-xs-l-2 text-sm">remove_invalid_characters</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Extension:</p>
+            <p class="p-xs-l-2 text-sm">md</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">Path:</p>
+            <p class="p-xs-l-2 text-sm">/Remove Invalid Characters, from Paths?!</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+        </div>
+
+        <div class="p-xs-y-4 border-b">
+            <p class="text-xs text-dark-soft text-uppercase">URL:</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/Remove Invalid Characters, from Paths?!</p>
+        </div>
+
+        <div class="p-xs-t-4">
+            <p class="text-xs text-dark-soft text-uppercase">Global Variable:</p>
+            <p class="p-xs-l-2 text-sm">some global variable</p>
+        </div>
+    </div>
+</div>
+                                    </div>
+
+                <div class="col-xs-8 demo-page">
+                        <h1>Simple Test</h1>
+    <h2>Remove® Invalid™ Characters, from Paths?!</h2>
+
+                    </div>
+            </div>
+        </div>
+    </body>
+</html>
+<!DOCTYPE html>

--- a/tests/source/_invalid_path_characters_test/remove_invalid_characters.md
+++ b/tests/source/_invalid_path_characters_test/remove_invalid_characters.md
@@ -1,0 +1,10 @@
+---
+extends: _layouts.simple
+title: Remove® Invalid™ Characters, from Paths?!
+author: Keith Damiani
+date: 2017-01-02
+number: 8
+category: faq
+---
+
+


### PR DESCRIPTION
Resolves https://github.com/tightenco/jigsaw/issues/145#issuecomment-329870894

When specifying a variable to use as a path name (e.g. `title`) and _not_ slugifying it (as with `'path' => '{title}'`), we need to strip out any characters that are not valid in URLs. This was the behavior in v1.0, but was inadvertently changed since then. I'm opting not to use `urlencode` because we want to maintain `/` characters (for nested paths and date processing), nor FILTER_VALIDATE_URL, which would remove spaces. A good old-fashioned regex restores behavior that is consistent with v1.0.