### PR TITLE
Added support for .mdown files, the default for mac computers.

### DIFF
--- a/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
+++ b/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
@@ -13,7 +13,7 @@ class MarkdownCollectionItemHandler
 
     public function shouldHandle($file)
     {
-        return in_array($file->getExtension(), ['markdown', 'md']);
+        return in_array($file->getExtension(), ['markdown', 'md', 'mdown']);
     }
 
     public function getItemVariables($file)

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -20,7 +20,7 @@ class MarkdownHandler
 
     public function shouldHandle($file)
     {
-        return in_array($file->getExtension(), ['markdown', 'md']);
+        return in_array($file->getExtension(), ['markdown', 'md', 'mdown']);
     }
 
     public function handleCollectionItem($file, PageData $pageData)
@@ -77,7 +77,7 @@ class MarkdownHandler
     {
         $replacements = ["<?php" => "<{{'?php'}}"];
 
-        if ($file->getFullExtension() == 'md') {
+        if ($file->getFullExtension() == 'md' || $file->getFullExtension() == 'mdown') {
             $replacements = array_merge([
                 "@" => "{{'@'}}",
                 "{{" => "@{{",

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -8,6 +8,7 @@ class ViewRenderer
     private $extensionEngines = [
         'md' => 'markdown',
         'markdown' => 'markdown',
+        'mdown' => 'markdown',
         'blade.md' => 'blade-markdown',
         'blade.markdown' => 'blade-markdown',
     ];


### PR DESCRIPTION
I noticed whenever I try and save a file with markdown or YAML in it, mac computers try to save default as .mdown

I tried to build the application with this file type but was met with an exception
```
[Exception]                          
  No matching collection item handler  
```

So I added this file type in as it seems logical that jigsaw should support it.