### PR TITLE
Set path and url to contain extra (non-html) Blade extensions if present

### DIFF
--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -4,6 +4,9 @@ class InputFile
 {
     protected $file;
     protected $basePath;
+    protected $extraBladeExtensions = [
+        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html'
+    ];
 
     public function __construct($file, $basePath)
     {
@@ -32,9 +35,12 @@ class InputFile
 
     public function getFullExtension()
     {
-        $extension = $this->getExtension();
+        return $this->isBladeFile() ? 'blade.' . $this->getExtension() : $this->getExtension();
+    }
 
-        return strpos($this->getBasename(), '.blade.' . $extension) > 0 ? 'blade.' . $extension : $extension;
+    public function getExtraBladeExtension()
+    {
+        return $this->isBladeFile() && in_array($this->getExtension(), $this->extraBladeExtensions) ? $this->getExtension() : '';
     }
 
     public function getRelativeFilePath()
@@ -42,6 +48,11 @@ class InputFile
         $relative_path = str_replace(realpath($this->basePath), '', realpath($this->file->getPathname()));
 
         return trimPath($relative_path);
+    }
+
+    protected function isBladeFile()
+    {
+        return strpos($this->getBasename(), '.blade.' . $this->getExtension()) > 0;
     }
 
     public function __call($method, $args)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -88,8 +88,8 @@ class SiteBuilder
     private function getMetaData($file, $baseUrl)
     {
         $filename = $file->getFilenameWithoutExtension();
-        $path = rightTrimPath($this->outputPathResolver->link($file->getRelativePath(), $filename, 'html'));
         $extension = $file->getFullExtension();
+        $path = rightTrimPath($this->outputPathResolver->link($file->getRelativePath(), $filename, $file->getExtraBladeExtension() ?: 'html'));
         $url = rightTrimPath($baseUrl) . '/' . trimPath($path);
 
         return compact('filename', 'baseUrl', 'path', 'extension', 'url');

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -10,6 +10,7 @@ class ViewRenderer
         'markdown' => 'markdown',
         'mdown' => 'markdown',
         'blade.md' => 'blade-markdown',
+        'blade.mdown' => 'blade-markdown',
         'blade.markdown' => 'blade-markdown',
     ];
     private $bladeExtensions = [

--- a/tests/snapshots/extension-url-test.atom
+++ b/tests/snapshots/extension-url-test.atom
@@ -1,0 +1,5 @@
+Testing getUrl handler in a file with non-html extension
+
+/extension-url-test.atom should be /extension-url-test.atom
+
+http://jigsaw-test.dev/extension-url-test.atom should end with /extension-url-test.atom

--- a/tests/source/extension-url-test.blade.atom
+++ b/tests/source/extension-url-test.blade.atom
@@ -1,0 +1,5 @@
+Testing getUrl handler in a file with non-html extension
+
+{{ $page->getPath() }} should be /extension-url-test.atom
+
+{{ $page->getUrl() }} should end with /extension-url-test.atom


### PR DESCRIPTION
This PR fixes an issue where "extra" whitelisted text-type files that can be preprocessed with Blade  (e.g. `.blade.js` or `.blade.atom`) were missing the extra extension (e.g. `.js` or `.atom`) from their `path` and `url` meta values, causing `getPath()` and `getUrl()` to return incorrect path references.