### PR TITLE
Bump Illuminate versions to 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         }
     },
     "require": {
-        "illuminate/container": "^5.5",
-        "illuminate/support": "^5.5",
-        "illuminate/view": "^5.5",
-        "symfony/console": "^2.5|^3.0|^4.0",
+        "illuminate/container": "^5.6",
+        "illuminate/support": "^5.6",
+        "illuminate/view": "^5.6",
+        "symfony/console": "~3.0|^4.0",
         "mockery/mockery": "^0.9.4",
         "mnapoli/front-yaml": "^1.5",
         "mnapoli/silly": "1.3 - 1.5"
@@ -35,6 +35,6 @@
         "jigsaw"
     ],
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~7.0"
     }
 }

--- a/jigsaw
+++ b/jigsaw
@@ -7,7 +7,7 @@ use TightenCo\Jigsaw\Console\ServeCommand;
 
 require_once(__DIR__ . '/jigsaw-core.php');
 
-$app = new Symfony\Component\Console\Application('Jigsaw', '1.0.9');
+$app = new Symfony\Component\Console\Application('Jigsaw', '1.0.10');
 $app->add($container[InitCommand::class]);
 $app->add(new BuildCommand($container));
 $app->add(new ServeCommand($container));


### PR DESCRIPTION
This PR adds support for version 5.6 of the Illuminate components, and bumps PHPUnit to 7.0.