### PR TITLE
Reference collection item content as strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "jigsaw"
     ],
     "require-dev": {
+        "mikey179/vfsStream": "^1.6",
         "phpunit/phpunit": "~7.0"
     }
 }

--- a/src/Collection/CollectionItem.php
+++ b/src/Collection/CollectionItem.php
@@ -44,6 +44,11 @@ class CollectionItem extends PageVariable
         return $this->_content;
     }
 
+    public function __toString()
+    {
+        return (String) $this->getContent();
+    }
+
     protected function missingHelperError($functionName)
     {
         return 'No function named "' . $functionName. '" for the collection "' . $this->_meta->collectionName . '" was found in the file "config.php".';

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -45,7 +45,7 @@ class InputFile
 
     public function getRelativeFilePath()
     {
-        $relative_path = str_replace(realpath($this->basePath), '', realpath($this->file->getPathname()));
+        $relative_path = str_replace(resolvePath($this->basePath), '', resolvePath($this->file->getPathname()));
 
         return trimPath($relative_path);
     }

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -49,7 +49,7 @@ class BladeHandler
                 $extension == 'php' ? 'html' : $extension,
                 $this->hasFrontMatter ?
                     $this->renderWithFrontMatter($file, $pageData) :
-                    $this->render($file->getRealPath(), $pageData),
+                    $this->render($file->getPathName(), $pageData),
                 $pageData
             )
         ]);

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -21,7 +21,7 @@ class DefaultHandler
     {
         return [
             new CopyFile(
-                $file->getRealPath(),
+                $file->getPathName(),
                 $file->getRelativePath(),
                 $file->getBasename('.' . $file->getExtension()),
                 $file->getExtension(),

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -19,6 +19,22 @@ function trimPath($path)
     return rightTrimPath(leftTrimPath($path));
 }
 
+function resolvePath($path)
+{
+    $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $path);
+    $segments = [];
+
+    collect(explode(DIRECTORY_SEPARATOR, $path))->filter()->each(function ($part) use (&$segments) {
+        if ($part == '..') {
+            array_pop($segments);
+        } elseif  ($part != '.') {
+            $segments[] = $part;
+        }
+    });
+
+    return implode(DIRECTORY_SEPARATOR, $segments);
+}
+
 /**
  * Get the path to the public folder.
  */

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests;
+
+use TightenCo\Jigsaw\DataLoader;
+use TightenCo\Jigsaw\SiteBuilder;
+use org\bovigo\vfs\vfsStream;
+
+class CollectionItemTest extends TestCase
+{
+    public function test_collection_item_contents_are_returned_when_item_is_referenced_as_a_string()
+    {
+        $config = collect(['collections' => ['collection' => []]]);
+        $yaml_header = implode("\n", ['---', 'section: content', '---']);
+        $vfs = vfsStream::setup('virtual', null, [
+            'source' => [
+                '_collection' => [
+                    'item.md' => $yaml_header . '### Collection Item Content',
+                ],
+                'test_get_content.blade.php' => '<div>{!! $collection->first()->getContent() !!}</div>',
+                'test_to_string.blade.php' => '<div>{!! $collection->first() !!}</div>',
+            ],
+        ]);
+
+        $this->buildSite($config, $vfs);
+
+        $this->assertEquals(
+            $vfs->getChild('build/test_get_content.html')->getContent(),
+            $vfs->getChild('build/test_to_string.html')->getContent()
+        );
+        $this->assertEquals(
+            '<div><h3>Collection Item Content</h3></div>',
+            $vfs->getChild('build/test_to_string.html')->getContent()
+        );
+    }
+
+    protected function buildSite($config = [], $vfs)
+    {
+        $this->app->config = $config;
+        $this->app->buildPath = [
+            'source' => $vfs->url() . '/source',
+            'destination' => $vfs->url() . '/build',
+        ];
+        $this->app->make(SiteBuilder::class)->build(
+            $this->app->buildPath['source'],
+            $this->app->buildPath['destination'],
+            $site_data = $this->buildSiteData($config, $vfs->url() . '/source')
+        );
+
+        return $site_data;
+    }
+
+    protected function buildSiteData($config, $source_url)
+    {
+        return $this->app->make(DataLoader::class)->load($source_url, $config);
+    }
+}


### PR DESCRIPTION
This PR is inspired by [this question](https://github.com/tightenco/jigsaw/issues/185#issuecomment-368795725), and adds a `__toString` method to `CollectionItem`, to return the contents of a collection item—parsed Markdown, for instance—whenever the item is referenced as a string. 

This would allow referencing a specific Markdown collection item in a Blade template like this:

```blade
@foreach ($notes as $note)
    {!! $note !!}
@endforeach
```

...instead of needing to reference `$note->getContent()`.

---

This PR includes some changes to path handling, replacing `realpath` and `getRealPath` which don't play nicely with the virtual file system used in our tests.

---

I'm working simultaneously on addressing the lack of support for `getContent()` in Blade files (https://github.com/tightenco/jigsaw/issues/172) which will also be affected by this change.