### PR TITLE
bump mockery to ^1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "^5.6",
         "illuminate/view": "^5.6",
         "symfony/console": "~3.0|^4.0",
-        "mockery/mockery": "^0.9.4",
+        "mockery/mockery": "^1.0.0",
         "mnapoli/front-yaml": "^1.5",
         "mnapoli/silly": "~1.3"
     },


### PR DESCRIPTION
Was experiencing conflicts in a few projects due to other packages using the 1.0.0 package of Mockery. Bumped jigsaw to 1.0.0 and ran the tests. All green! 👍