### PR TITLE
Add a confirmation prompt to the "init" command

### DIFF
--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -46,7 +46,7 @@ class InitCommand extends Command
             $this->info('Running it again may overwrite important files.');
             $this->info('');
 
-            if (! $this->confirm('Do you wish to continue?')) {
+            if (! $this->confirm('Do you wish to continue? ')) {
                 return;
             }
         }

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -32,9 +32,26 @@ class InitCommand extends Command
             $this->base .= '/' . $base;
         }
 
-        $this->scaffoldSite();
-        $this->scaffoldMix();
-        $this->info('Site initialized successfully!');
+        $this->ifAlreadyScaffoldedWarnBeforeDoingTheFollowing(function () {
+            $this->scaffoldSite();
+            $this->scaffoldMix();
+            $this->info('Site initialized successfully!');
+        });
+    }
+
+    private function ifAlreadyScaffoldedWarnBeforeDoingTheFollowing($callback)
+    {
+        if ($this->files->exists($this->base . '/config.php')) {
+            $this->info('It looks like you\'ve already run "jigsaw init" on this project.');
+            $this->info('Running it again may overwrite important files.');
+            $this->info('');
+
+            if (! $this->confirm('Do you wish to continue?')) {
+                return;
+            }
+        }
+
+        $callback();
     }
 
     private function scaffoldSite()


### PR DESCRIPTION
Right now, if you run `jigsaw init` on an existing jigsaw project, it will nuke your project by overwriting all the jigsaw files.

This PR should add a confirmation prompt to the command to alert users what they are about to do. It should be conditionally added based on if there is an existing `config.php` already or not.

![image](https://user-images.githubusercontent.com/3670578/39055147-6fb70ce0-4481-11e8-8590-c39fbcb72a6f.png)
