### PR TITLE
Fix issue with getCollections in afterCollections or afterBuild event listeners

### DIFF
--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -61,7 +61,7 @@ class Jigsaw
     {
         return $this->siteData->get('collections') ?
             $this->siteData->get('collections')->keys() :
-            $this->siteData->forget('page');
+            $this->siteData->except('page');
     }
 
     public function getConfig($key = null)


### PR DESCRIPTION
Fixes https://github.com/tightenco/jigsaw/issues/202

- Replace `forget` with `except` in Jigsaw.php `getCollections` helper