### PR TITLE
Expose bladeCompiler in blade.php to make extending blade easier and more future-proof

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -101,7 +101,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
         return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
 
-    (new BladeDirectivesFile($c['cwd'] . '/blade.php'))->register($bladeCompiler);
+    BladeDirectivesFile::init($c['cwd'] . '/blade.php', $bladeCompiler)->register();
 
     $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
 

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -101,7 +101,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
         return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
 
-    BladeDirectivesFile::init($c['cwd'] . '/blade.php', $bladeCompiler)->register();
+	(new BladeDirectivesFile($c['cwd'] . '/blade.php', $bladeCompiler))->register();
 
     $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
 

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -101,7 +101,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
         return new BladeMarkdownEngine($compilerEngine, $c[FrontMatterParser::class]);
     });
 
-	(new BladeDirectivesFile($c['cwd'] . '/blade.php', $bladeCompiler))->register();
+    (new BladeDirectivesFile($c['cwd'] . '/blade.php', $bladeCompiler))->register();
 
     $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
 

--- a/src/File/BladeDirectivesFile.php
+++ b/src/File/BladeDirectivesFile.php
@@ -4,17 +4,30 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeDirectivesFile
 {
+    /** @var BladeCompiler */
+    protected $bladeCompiler;
+
+    /** @var array */
     protected $directives;
 
-    public function __construct($file_path)
+    /**
+     * @param string $file_path Path to file containing array of blade directives
+     * @param BladeCompiler $bladeCompiler
+     */
+    public function __construct($file_path, BladeCompiler $bladeCompiler)
     {
+        $this->bladeCompiler = $bladeCompiler;
         $this->directives = file_exists($file_path) ? include $file_path : [];
     }
 
-    public function register(BladeCompiler $compiler)
+	public static function init($file_path, BladeCompiler $compiler) {
+        return new static($file_path, $compiler);
+    }
+
+    public function register()
     {
-        collect($this->directives)->each(function ($callback, $directive) use ($compiler) {
-            $compiler->directive($directive, $callback);
+        collect($this->directives)->each(function ($callback, $directive) {
+            $this->bladeCompiler->directive($directive, $callback);
         });
     }
 }

--- a/src/File/BladeDirectivesFile.php
+++ b/src/File/BladeDirectivesFile.php
@@ -18,6 +18,9 @@ class BladeDirectivesFile
     {
         $this->bladeCompiler = $bladeCompiler;
         $this->directives = file_exists($file_path) ? include $file_path : [];
+        if (!is_array($this->directives)) {
+            $this->directives = [];
+        }
     }
 
 	public static function init($file_path, BladeCompiler $compiler) {

--- a/src/File/BladeDirectivesFile.php
+++ b/src/File/BladeDirectivesFile.php
@@ -4,25 +4,19 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class BladeDirectivesFile
 {
-    /** @var BladeCompiler */
     protected $bladeCompiler;
-
-    /** @var array */
     protected $directives;
 
-    /**
-     * @param string $file_path Path to file containing array of blade directives
-     * @param BladeCompiler $bladeCompiler
-     */
     public function __construct($file_path, BladeCompiler $bladeCompiler)
     {
         $this->bladeCompiler = $bladeCompiler;
         $this->directives = file_exists($file_path) ? include $file_path : [];
-        if (!is_array($this->directives)) {
+
+        if (! is_array($this->directives)) {
             $this->directives = [];
         }
     }
-    
+
     public function register()
     {
         collect($this->directives)->each(function ($callback, $directive) {

--- a/src/File/BladeDirectivesFile.php
+++ b/src/File/BladeDirectivesFile.php
@@ -22,11 +22,7 @@ class BladeDirectivesFile
             $this->directives = [];
         }
     }
-
-	public static function init($file_path, BladeCompiler $compiler) {
-        return new static($file_path, $compiler);
-    }
-
+    
     public function register()
     {
         collect($this->directives)->each(function ($callback, $directive) {


### PR DESCRIPTION
In `blade.php` the `BladeCompiler` is now exposed as `$bladeCompiler`;

An example of registering a component alias:

### blade.php
```php
/** @var \Illuminate\View\Compilers\BladeCompiler $bladeCompiler */
$bladeCompiler->component('_components.title');

// extend more
$bladeCompiler->include(...);
$bladeCompiler->directive(...);

// make sure you still return an array!
return [
    // custom directives... 
    // Same thing as calling $bladeCompiler->directive(...) above
];
```

### index.blade.php
```blade
{{--before--}}
@component('_components.title')
    Title 1
@endcomponent

{{--after--}}
@title
    Title 2
@endtitle
```