### PR TITLE
Use ParsedownExtra as default markdown parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "mockery/mockery": "^1.0.0",
         "mnapoli/front-yaml": "^1.5",
         "mnapoli/silly": "1.3 - 1.5",
-        "symfony/yaml": "^4.0"
+        "symfony/yaml": "^4.0",
+        "erusev/parsedown-extra": "^0.7.1"
     },
     "bin": [
         "jigsaw"

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -8,7 +8,6 @@ use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
-use Mni\FrontYAML\Bridge\Parsedown\ParsedownParser;
 use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use Mni\FrontYAML\Parser;
@@ -32,6 +31,7 @@ use TightenCo\Jigsaw\Loaders\CollectionDataLoader;
 use TightenCo\Jigsaw\Loaders\CollectionRemoteItemLoader;
 use TightenCo\Jigsaw\Loaders\DataLoader;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
+use TightenCo\Jigsaw\Parsers\ParsedownExtraParser;
 use TightenCo\Jigsaw\PathResolvers\BasicOutputPathResolver;
 use TightenCo\Jigsaw\PathResolvers\CollectionPathResolver;
 use TightenCo\Jigsaw\SiteBuilder;
@@ -69,7 +69,7 @@ $container->bind('outputPathResolver', function ($c) {
 
 $container->bind(YAMLParser::class, SymfonyYAMLParser::class);
 
-$container->bind(MarkdownParser::class, ParsedownParser::class);
+$container->bind(MarkdownParser::class, ParsedownExtraParser::class);
 
 $container->bind(Parser::class, function ($c) {
     return new Parser($c[YAMLParser::class], $c[MarkdownParser::class]);

--- a/src/Parsers/ParsedownExtraParser.php
+++ b/src/Parsers/ParsedownExtraParser.php
@@ -1,0 +1,17 @@
+<?php namespace TightenCo\Jigsaw\Parsers;
+
+use Mni\FrontYAML\Markdown\MarkdownParser;
+use ParsedownExtra;
+
+class ParsedownExtraParser implements MarkdownParser
+{
+    public function __construct(ParsedownExtra $parsedownExtra = null)
+    {
+        $this->parser = $parsedownExtra ?: new ParsedownExtra();
+    }
+
+    public function parse($markdown)
+    {
+        return $this->parser->parse($markdown);
+    }
+}

--- a/tests/MarkdownExtraTest.php
+++ b/tests/MarkdownExtraTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests;
+
+use TightenCo\Jigsaw\Handlers\MarkdownHandler;
+use TightenCo\Jigsaw\IterableObject;
+use TightenCo\Jigsaw\PageData;
+
+class MarkdownExtraTest extends TestCase
+{
+    public function test_parse_markdown_inside_html_blocks()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.md' => $this->getYamlHeader() . '<div markdown="1">This is *true* markdown text.</div>',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            "<div><div>\n<p>This is <em>true</em> markdown text.</p>\n</div></div>",
+            $files->getChild('build/test.html')->getContent()
+        );
+    }
+
+    public function test_can_specify_id_in_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.md' => $this->getYamlHeader() . '### Testing ID ### {#test-id}',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><h3 id="test-id">Testing ID</h3></div>',
+            $files->getChild('build/test.html')->getContent()
+        );
+    }
+
+    public function test_can_specify_internal_anchor_links_in_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.md' => $this->getYamlHeader() . '[Link back to header 1](#header1)',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><p><a href="#header1">Link back to header 1</a></p></div>',
+            $files->getChild('build/test.html')->getContent()
+        );
+    }
+
+    public function test_can_specify_class_name_in_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.md' => $this->getYamlHeader() . '### Testing class ### {.test-class}',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><h3 class="test-class">Testing class</h3></div>',
+            $files->getChild('build/test.html')->getContent()
+        );
+    }
+
+    public function getYamlHeader()
+    {
+        return implode("\n", ['---', 'extends: _layouts.master', 'section: content', '---']);
+    }
+}


### PR DESCRIPTION
This PR changes the default markdown parser to ParsedownExtra, which implements the Markdown Extra standard, as requested [here](https://github.com/tightenco/jigsaw/issues/206#issuecomment-378512432).