### PR TITLE
Performance & a Progress bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "illuminate/support": "^5.6",
         "illuminate/view": "^5.6",
         "symfony/console": "~3.0|^4.0",
-        "mockery/mockery": "^1.0.0",
         "mnapoli/front-yaml": "^1.5",
         "symfony/yaml": "^4.0",
         "erusev/parsedown-extra": "^0.7.1"

--- a/jigsaw
+++ b/jigsaw
@@ -8,7 +8,7 @@ use TightenCo\Jigsaw\Console\UseCommand;
 
 require_once(__DIR__ . '/jigsaw-core.php');
 
-$app = new Symfony\Component\Console\Application('Jigsaw', '1.2.2');
+$app = new Symfony\Component\Console\Application('Jigsaw', '2.0');
 $app->add($container[InitCommand::class]);
 $app->add($container[UseCommand::class]);
 $app->add(new BuildCommand($container));

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
@@ -38,6 +37,7 @@ use TightenCo\Jigsaw\SiteBuilder;
 use TightenCo\Jigsaw\View\BladeMarkdownEngine;
 use TightenCo\Jigsaw\View\MarkdownEngine;
 use TightenCo\Jigsaw\View\ViewRenderer;
+use TightenCo\Jigsaw\Events\FakeDispatcher;
 
 if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
@@ -105,7 +105,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
 
     $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
 
-    return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
+    return new Factory($resolver, $finder, new FakeDispatcher);
 });
 
 $container->bind(ViewRenderer::class, function ($c) {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -34,7 +34,7 @@ class BuildCommand extends Command
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
         }
 
-        $this->app->make(Jigsaw::class)->setConsoleOutput($this->output)->build($env);
+        $this->app->make(Jigsaw::class)->build($env);
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -34,7 +34,7 @@ class BuildCommand extends Command
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
         }
 
-        $this->app->make(Jigsaw::class)->build($env);
+        $this->app->make(Jigsaw::class)->setConsoleOutput($this->output)->build($env);
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -26,6 +26,8 @@ class BuildCommand extends Command
 
     protected function fire()
     {
+        $startTime = microtime(true);
+
         $env = $this->input->getArgument('env');
         $this->includeEnvironmentConfig($env);
         $this->updateBuildPaths($env);
@@ -35,7 +37,13 @@ class BuildCommand extends Command
         }
 
         $this->app->make(Jigsaw::class)->build($env);
-        $this->info('Site built successfully!');
+
+        $buildTime = microtime(true) - $startTime;
+
+        $this->info(sprintf(
+                    "Site built successfully! (env: %s, build time: %.2f sec)", 
+                    $env, $buildTime
+                ));
     }
 
     private function includeEnvironmentConfig($env)

--- a/src/Events/FakeDispatcher.php
+++ b/src/Events/FakeDispatcher.php
@@ -1,0 +1,18 @@
+<?php namespace TightenCo\Jigsaw\Events;
+
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+
+
+
+class FakeDispatcher implements DispatcherContract
+{
+    public function listen($events, $listener){}
+    public function hasListeners($eventName){}
+    public function subscribe($subscriber){}
+    public function until($event, $payload = []){}
+    public function dispatch($event, $payload = [], $halt = false){}
+    public function push($event, $payload = []){}
+    public function flush($event){}
+    public function forget($event){}
+    public function forgetPushed(){}
+}

--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -8,8 +8,7 @@ class Filesystem extends BaseFilesystem
 {
     public function getFile($directory, $filename)
     {
-        $filePath = rtrim($directory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
-
+        $filePath = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
         return new SplFileInfo($filePath, $directory, $filename);
     }
 

--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -2,12 +2,15 @@
 
 use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class Filesystem extends BaseFilesystem
 {
     public function getFile($directory, $filename)
     {
-        return iterator_to_array(Finder::create()->path(rtrim($directory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename)->append([]), false);
+        $filePath = rtrim($directory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename;
+
+        return new SplFileInfo($filePath, $directory, $filename);
     }
 
     public function putWithDirectories($file_path, $contents)

--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -7,7 +7,7 @@ class Filesystem extends BaseFilesystem
 {
     public function getFile($directory, $filename)
     {
-        return iterator_to_array(Finder::create()->files()->name($filename)->in($directory), false)[0];
+        return iterator_to_array(Finder::create()->path(rtrim($directory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$filename)->append([]), false);
     }
 
     public function putWithDirectories($file_path, $contents)

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -19,7 +19,7 @@ class DefaultHandler
 
     public function handle($file, $pageData)
     {
-        return [
+        return collect([
             new CopyFile(
                 $file->getPathName(),
                 $file->getRelativePath(),
@@ -27,6 +27,6 @@ class DefaultHandler
                 $file->getExtension(),
                 $pageData
             )
-        ];
+        ]);
     }
 }

--- a/src/Handlers/IgnoredHandler.php
+++ b/src/Handlers/IgnoredHandler.php
@@ -9,6 +9,6 @@ class IgnoredHandler
 
     public function handle($file, $data)
     {
-        return [];
+        return collect();
     }
 }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -1,6 +1,9 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Jigsaw
 {
@@ -10,6 +13,7 @@ class Jigsaw
     protected $siteData;
     protected $dataLoader;
     protected $siteBuilder;
+    protected $consoleOutput;
 
     public function __construct($app, $dataLoader, $remoteItemLoader, $siteBuilder)
     {
@@ -17,6 +21,13 @@ class Jigsaw
         $this->dataLoader = $dataLoader;
         $this->remoteItemLoader = $remoteItemLoader;
         $this->siteBuilder = $siteBuilder;
+    }
+
+    public function setConsoleOutput(OutputInterface $consoleOutput)
+    {
+        $this->consoleOutput = $consoleOutput;
+
+        return $this;
     }
 
     public function build($env)
@@ -31,15 +42,19 @@ class Jigsaw
 
         $this->fireEvent('afterCollections');
 
-        $this->outputPaths = $this->siteBuilder->build(
-            $this->getSourcePath(),
-            $this->getDestinationPath(),
-            $this->siteData
-        );
+        $this->outputPaths = $this->siteBuilder
+            ->setConsoleOutput($this->consoleOutput)
+            ->build(
+                $this->getSourcePath(),
+                $this->getDestinationPath(),
+                $this->siteData
+            );
 
         $this->remoteItemLoader->cleanup();
 
         $this->fireEvent('afterBuild');
+
+        return $this;
     }
 
     protected function fireEvent($event)
@@ -72,6 +87,8 @@ class Jigsaw
     public function setConfig($key, $value)
     {
         data_set($this->siteData->page, $key, $value);
+
+        return $this;
     }
 
     public function getSourcePath()
@@ -85,6 +102,8 @@ class Jigsaw
             'source' => $path,
             'destination' => $this->app->buildPath['destination'],
         ];
+
+        return $this;
     }
 
     public function getDestinationPath()
@@ -98,6 +117,8 @@ class Jigsaw
             'source' => $this->app->buildPath['source'],
             'destination' => $path,
         ];
+
+        return $this;
     }
 
     public function getFilesystem()
@@ -112,21 +133,21 @@ class Jigsaw
 
     public function readSourceFile($fileName)
     {
-        return $this->getFilesystem()->get($this->getSourcePath() . '/' . $fileName);
+        return $this->getFilesystem()->get($this->getSourcePath().'/'.$fileName);
     }
 
     public function writeSourceFile($fileName, $contents)
     {
-        return $this->getFilesystem()->putWithDirectories($this->getSourcePath() . '/' . $fileName, $contents);
+        return $this->getFilesystem()->putWithDirectories($this->getSourcePath().'/'.$fileName, $contents);
     }
 
     public function readOutputFile($fileName)
     {
-        return $this->getFilesystem()->get($this->getDestinationPath() . '/' . $fileName);
+        return $this->getFilesystem()->get($this->getDestinationPath().'/'.$fileName);
     }
 
     public function writeOutputFile($fileName, $contents)
     {
-        return $this->getFilesystem()->putWithDirectories($this->getDestinationPath() . '/' . $fileName, $contents);
+        return $this->getFilesystem()->putWithDirectories($this->getDestinationPath().'/'.$fileName, $contents);
     }
 }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -3,7 +3,6 @@
 namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Jigsaw
@@ -136,21 +135,21 @@ class Jigsaw
 
     public function readSourceFile($fileName)
     {
-        return $this->getFilesystem()->get($this->getSourcePath().'/'.$fileName);
+        return $this->getFilesystem()->get($this->getSourcePath() . '/' . $fileName);
     }
 
     public function writeSourceFile($fileName, $contents)
     {
-        return $this->getFilesystem()->putWithDirectories($this->getSourcePath().'/'.$fileName, $contents);
+        return $this->getFilesystem()->putWithDirectories($this->getSourcePath() . '/' . $fileName, $contents);
     }
 
     public function readOutputFile($fileName)
     {
-        return $this->getFilesystem()->get($this->getDestinationPath().'/'.$fileName);
+        return $this->getFilesystem()->get($this->getDestinationPath() . '/' . $fileName);
     }
 
     public function writeOutputFile($fileName, $contents)
     {
-        return $this->getFilesystem()->putWithDirectories($this->getDestinationPath().'/'.$fileName, $contents);
+        return $this->getFilesystem()->putWithDirectories($this->getDestinationPath() . '/' . $fileName, $contents);
     }
 }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -36,6 +36,7 @@ class Jigsaw
         $this->siteData = $this->dataLoader->loadSiteData($this->app->config);
         $this->fireEvent('beforeBuild');
 
+        $this->consoleOutput->writeln('<comment>Load collections ...</comment>');
         $this->remoteItemLoader->write($this->siteData->collections, $this->getSourcePath());
         $collectionData = $this->dataLoader->loadCollectionData($this->siteData, $this->getSourcePath());
         $this->siteData = $this->siteData->addCollectionData($collectionData);

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -15,7 +15,6 @@ class Jigsaw
     protected $dataLoader;
     protected $siteBuilder;
     protected $consoleOutput;
-    protected $verbose;
 
     public function __construct($app, $dataLoader, $remoteItemLoader, $siteBuilder)
     {

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -4,6 +4,7 @@ namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Jigsaw
 {
@@ -14,6 +15,7 @@ class Jigsaw
     protected $dataLoader;
     protected $siteBuilder;
     protected $consoleOutput;
+    protected $verbose;
 
     public function __construct($app, $dataLoader, $remoteItemLoader, $siteBuilder)
     {
@@ -21,11 +23,12 @@ class Jigsaw
         $this->dataLoader = $dataLoader;
         $this->remoteItemLoader = $remoteItemLoader;
         $this->siteBuilder = $siteBuilder;
+        $this->consoleOutput = new ConsoleOutput();
     }
 
-    public function setConsoleOutput(OutputInterface $consoleOutput)
+    public function setVerbose($verbose)
     {
-        $this->consoleOutput = $consoleOutput;
+        $this->consoleOutput->setVerbosity($verbose ? 0 : -1);
 
         return $this;
     }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -9,7 +9,6 @@ class Jigsaw
 {
     public $app;
     protected $env;
-    protected $outputPaths;
     protected $siteData;
     protected $dataLoader;
     protected $siteBuilder;
@@ -44,7 +43,7 @@ class Jigsaw
 
         $this->fireEvent('afterCollections');
 
-        $this->outputPaths = $this->siteBuilder
+        $this->siteBuilder
             ->setConsoleOutput($this->consoleOutput)
             ->build(
                 $this->getSourcePath(),
@@ -126,11 +125,6 @@ class Jigsaw
     public function getFilesystem()
     {
         return $this->app->make(Filesystem::class);
-    }
-
-    public function getOutputPaths()
-    {
-        return $this->outputPaths ?: [];
     }
 
     public function readSourceFile($fileName)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -20,8 +20,14 @@ class SiteBuilder
 
     public function build($source, $dest, $siteData)
     {
-        $this->prepareDirectories([$this->cachePath, $dest]);
-        $outputFiles = $this->writeFiles($source, $dest, $siteData);
+        $this->prepareDirectory($this->cachePath);
+
+        $generatedFiles = $this->generateFiles($source, $siteData);
+
+        $this->prepareDirectory($dest);
+
+        $outputFiles = $this->writeFiles($dest, $generatedFiles);
+        
         $this->cleanup();
 
         return $outputFiles;
@@ -55,13 +61,18 @@ class SiteBuilder
         $this->files->deleteDirectory($this->cachePath);
     }
 
-    private function writeFiles($source, $destination, $siteData)
+    private function generateFiles($source, $siteData)
     {
         return collect($this->files->allFiles($source))->map(function ($file) use ($source) {
             return new InputFile($file, $source);
         })->flatMap(function ($file) use ($siteData) {
             return $this->handle($file, $siteData);
-        })->map(function ($file) use ($destination) {
+        });
+    }
+
+    private function writeFiles($destination, $files)
+    {
+        return $files->map(function ($file) use ($destination) {
             return $this->writeFile($file, $destination);
         });
     }

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -33,13 +33,9 @@ class SiteBuilder
     public function build($source, $dest, $siteData)
     {
         $this->prepareDirectory($this->cachePath);
-
         $outputFiles = $this->generateFiles($source, $siteData);
-
         $this->prepareDirectory($dest);
-
         $outputFiles = $this->writeFiles($dest, $outputFiles);
-
         $this->cleanup();
 
         return $outputFiles;
@@ -78,12 +74,9 @@ class SiteBuilder
     private function generateFiles($source, $siteData)
     {
         $this->consoleOutput->writeln('<comment>Generating files from source</comment>');
-
         $files = collect($this->files->allFiles($source));
-
         $progressBar = new ProgressBar($this->consoleOutput, $files->count());
         $progressBar->start();
-
         $files = $files->map(function ($file) use ($source) {
             return new InputFile($file, $source);
         })->flatMap(function ($file) use ($siteData, $progressBar) {
@@ -91,7 +84,6 @@ class SiteBuilder
 
             return $this->handle($file, $siteData);
         });
-
         $progressBar->finish();
         $this->consoleOutput->writeln('');
 
@@ -100,19 +92,11 @@ class SiteBuilder
 
     private function writeFiles($destination, $files)
     {
-        $this->consoleOutput->writeln('<comment>Writing files to destination</comment>');
+        $this->consoleOutput->writeln('<comment>Writing files to destination...</comment>');
 
-        $progressBar = new ProgressBar($this->consoleOutput, $files->count());
-        $progressBar->start();
-
-        $files = $files->map(function ($file) use ($destination, $progressBar) {
-            $progressBar->advance();
-
+        $files = $files->map(function ($file) use ($destination) {
             return $this->writeFile($file, $destination);
         });
-
-        $progressBar->finish();
-        $this->consoleOutput->writeln('');
 
         return $files;
     }
@@ -145,7 +129,7 @@ class SiteBuilder
         $filename = $file->getFilenameWithoutExtension();
         $extension = $file->getFullExtension();
         $path = rightTrimPath($this->outputPathResolver->link($file->getRelativePath(), $filename, $file->getExtraBladeExtension() ?: 'html'));
-        $url = rightTrimPath($baseUrl).'/'.trimPath($path);
+        $url = rightTrimPath($baseUrl) . '/' . trimPath($path);
 
         return compact('filename', 'baseUrl', 'path', 'extension', 'url');
     }

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -23,7 +23,7 @@ class SiteBuilder
         $this->handlers = $handlers;
     }
 
-    public function setConsoleOutput(OutputInterface $consoleOutput)
+    public function setConsoleOutput($consoleOutput)
     {
         $this->consoleOutput = $consoleOutput;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use TightenCo\Jigsaw\File\InputFile;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\Loaders\DataLoader;
 use org\bovigo\vfs\vfsStream;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class TestCase extends BaseTestCase
 {
@@ -79,7 +80,7 @@ class TestCase extends BaseTestCase
         ];
 
         $jigsaw = $this->app->make(Jigsaw::class);
-        $jigsaw->build('test');
+        $jigsaw->setVerbose(false)->build('test');
 
         return $jigsaw;
     }


### PR DESCRIPTION

I'm using Jigsaw for a project that has many source files, so I needed a short generation time to limit the down time (because I do the build in the production).

- Clean build folder after the generation, to make the down time short. (currently, cleaning happens before)
- Faster by 70%...
- & a Progress bar


![Before](https://user-images.githubusercontent.com/114794/41507632-d3e32178-723e-11e8-8a90-9eb2f692f812.png)
↓
![After](https://user-images.githubusercontent.com/114794/41507633-d40df38a-723e-11e8-87ac-4ccd2425f780.png)


To try,  copy the following to your composer.json:

```
{
    "repositories": [{
        "type": "vcs",
        "url": "https://github.com/abdumu/jigsaw"
    }],
    "require": {
        "tightenco/jigsaw": "dev-master"
    }
}
```
