### PR TITLE
Added new host option to the serve command

### DIFF
--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -24,6 +24,13 @@ class ServeCommand extends Command
                 'local'
             )
             ->addOption(
+                'host',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'What hostname or ip address should we use?',
+                'localhost'
+            )
+            ->addOption(
                 'port',
                 'p',
                 InputOption::VALUE_REQUIRED,
@@ -35,11 +42,12 @@ class ServeCommand extends Command
     protected function fire()
     {
         $env = $this->input->getArgument('environment');
+        $host = $this->input->getOption('host');
         $port = $this->input->getOption('port');
 
-        $this->info("Server started on http://localhost:{$port}");
+        $this->info("Server started on http://{$host}:{$port}");
 
-        passthru("php -S localhost:{$port} -t " . escapeshellarg($this->getBuildPath($env)));
+        passthru("php -S {$host}:{$port} -t " . escapeshellarg($this->getBuildPath($env)));
     }
 
     private function getBuildPath($env)


### PR DESCRIPTION
This PR is in response to issue #216 and adds a new optional --host option to the serve command, allowing users to specify the hostname or ip address to bind to.