### PR TITLE
Drop non-generated CSS file

### DIFF
--- a/stubs/site/source/_layouts/master.blade.php
+++ b/stubs/site/source/_layouts/master.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="/css/main.css">
+        <link rel="stylesheet" href="/assets/css/main.css">
     </head>
     <body>
         @yield('body')


### PR DESCRIPTION
Since we have Mix out of the box, we can drop the old default `main.css` file, as it's just confusing at this point.