### PR TITLE
make Jigsaw main class macroable

### DIFF
--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -1,9 +1,12 @@
 <?php namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
+use Illuminate\Support\Traits\Macroable;
 
 class Jigsaw
 {
+    use Macroable;
+
     public $app;
     protected $env;
     protected $outputPaths;


### PR DESCRIPTION
This PR changes the main Jigsaw class to be macroable, using the default Laravel trait, as provided by illuminate/support.

I personally would like to use this to access the protected properties of the Jigsaw object. For instance, this could be useful to modify (or add) Collections.

Using macros appears to be the only (or at least, best) option to accomplish this, since the Jigsaw architechture doesn't really allow modifying or appending to the Jigsaw class anywhere else.