### PR TITLE
Fixes to IterableObject

### DIFF
--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -52,9 +52,13 @@ class IterableObject extends BaseCollection implements ArrayAccess
 
     protected function makeIterable($items)
     {
+        if ($items instanceof IterableObject) {
+            return $items;
+        }
+
         return new IterableObject(collect($items)->map(function ($item) {
-            return $this->isArrayable($item) ? $this->makeIterable($item) : $item;
-        }));
+                return $this->isArrayable($item) ? $this->makeIterable($item) : $item;
+            }));
     }
 
     protected function isArrayable($element)

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -61,8 +61,8 @@ class IterableObject extends BaseCollection implements ArrayAccess
         }
 
         return new IterableObject(collect($items)->map(function ($item) {
-                return $this->isArrayable($item) ? $this->makeIterable($item) : $item;
-            }));
+            return $this->isArrayable($item) ? $this->makeIterable($item) : $item;
+        }));
     }
 
     protected function isArrayable($element)

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -38,6 +38,10 @@ class IterableObject extends BaseCollection implements ArrayAccess
     public function set($key, $value)
     {
         data_set($this->items, $key, $this->isArrayable($value) ? $this->makeIterable($value) : $value);
+
+        if ($first_key = array_get(explode('.', $key), 0)) {
+            $this->putIterable($first_key, $this->get($first_key));
+        }
     }
 
     public function putIterable($key, $element)

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests;
+
+use TightenCo\Jigsaw\IterableObject;
+use TightenCo\Jigsaw\Jigsaw;
+use TightenCo\Jigsaw\SiteBuilder;
+use org\bovigo\vfs\vfsStream;
+
+class IterableObjectTest extends TestCase
+{
+    public function test_item_in_iterable_object_can_be_referenced_as_object_property()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ]);
+
+        $this->assertEquals(2, $iterable_object->b);
+    }
+
+    public function test_item_in_iterable_object_can_be_referenced_as_array_element()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ]);
+
+        $this->assertEquals(2, $iterable_object['b']);
+    }
+
+    public function test_item_in_iterable_object_can_be_referenced_as_collection_element()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ]);
+
+        $this->assertEquals(2, $iterable_object->get('b'));
+    }
+
+    public function test_iterable_object_can_be_iterated_over_like_a_collection()
+    {
+        $array = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+
+        (new IterableObject($array))->each(function ($item, $index) use ($array) {
+            $this->assertEquals($array[$index], $item);
+        });
+    }
+
+    public function test_arrays_can_be_made_iterable_objects_when_adding_to_an_iterable_object()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->putIterable('b', ['c' => 3]);
+
+        $this->assertEquals(IterableObject::class, get_class($iterable_object->b));
+        $this->assertEquals(3, $iterable_object->b->c);
+    }
+
+    public function test_collections_can_be_made_iterable_objects_when_adding_to_an_iterable_object()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->putIterable('b', collect(['c' => 3]));
+
+        $this->assertEquals(IterableObject::class, get_class($iterable_object->b));
+        $this->assertEquals(3, $iterable_object->b->c);
+    }
+
+    public function test_non_arrayable_items_are_not_changed_when_adding_with_makeIterable()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->putIterable('b', 'c');
+
+        $this->assertTrue(is_string($iterable_object->b));
+    }
+
+    public function test_objects_that_extend_IterableObject_are_not_changed_when_adding_with_makeIterable()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->putIterable('b', new ExtendsIterableObject(['c' => 3]));
+
+        $this->assertEquals(ExtendsIterableObject::class, get_class($iterable_object->b));
+        $this->assertTrue($iterable_object->b instanceof ExtendsIterableObject);
+        $this->assertTrue($iterable_object->b instanceof IterableObject);
+    }
+
+    public function test_item_can_be_added_to_iterable_object_with_dot_notation()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->set('b.c', collect(['d' => 3]));
+
+        $this->assertEquals(3, $iterable_object->b['c']['d']);
+    }
+
+    public function test_nested_items_added_with_dot_notation_are_themselves_made_iterable()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+        ]);
+
+        $iterable_object->set('b.c', collect(['d' => 3]));
+
+        $this->assertEquals(3, $iterable_object->b->c->d);
+        $this->assertTrue($iterable_object->b instanceof IterableObject);
+        $this->assertTrue($iterable_object->b->c instanceof IterableObject);
+        $this->assertTrue(is_int($iterable_object->b->c->d));
+    }
+
+    public function test_intermediate_items_that_extend_IterableObject_are_not_changed_when_adding_new_items_with_dot_notation()
+    {
+        $iterable_object = new IterableObject([
+            'a' => 1,
+            'b' => new ExtendsIterableObject(['c' => 3]),
+        ]);
+
+        $iterable_object->set('b.d', collect(['e' => 4]));
+
+        $this->assertTrue($iterable_object->b instanceof ExtendsIterableObject);
+        $this->assertEquals(3, $iterable_object->b->c);
+        $this->assertTrue(is_int($iterable_object->b->c));
+        $this->assertTrue($iterable_object->b->d instanceof IterableObject);
+        $this->assertEquals(4, $iterable_object->b->d->e);
+        $this->assertTrue(is_int($iterable_object->b->d->e));
+    }
+}
+
+class ExtendsIterableObject extends IterableObject
+{
+    //
+}


### PR DESCRIPTION
This PR fixes a couple issues with adding new items to an `IterableObject`:

- Objects that extend `IterableObject`, such as `PageVariable`, were incorrectly getting converted to a standard `IterableObject` when added with `makeIterable`, causing those objects to lose their extended functionality.
- When adding an object using `set` and dot notation, the final item as made into an `IterableObject`, but not any of new intermediate items.
- Started adding tests for `IterableObject`