### PR TITLE
adding PHP CS Fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,8 +1,9 @@
 <?php
  $finder = PhpCsFixer\Finder::create()
     ->name('*.php')
-    ->in(__DIR__.DIRECTORY_SEPARATOR.'src')
-    ->in(__DIR__.DIRECTORY_SEPARATOR.'tests');
+    ->in(__DIR__ . DIRECTORY_SEPARATOR . 'src')
+    ->in(__DIR__ . DIRECTORY_SEPARATOR . 'tests');
+
  return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
@@ -18,4 +19,4 @@
         'trailing_comma_in_multiline_array' => true,
         'yoda_style' => false,
     ])
-    ->setFinder($finder); 
+    ->setFinder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,21 @@
+<?php
+ $finder = PhpCsFixer\Finder::create()
+    ->name('*.php')
+    ->in(__DIR__.DIRECTORY_SEPARATOR.'src')
+    ->in(__DIR__.DIRECTORY_SEPARATOR.'tests');
+ return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'align_multiline_comment' => ['comment_type' => 'all_multiline'],
+        'array_syntax' => ['syntax' => 'short'],
+        'concat_space' => ['spacing' => 'one'],
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'not_operator_with_successor_space' => true,
+        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_order' => true,
+        'trailing_comma_in_multiline_array' => true,
+        'yoda_style' => false,
+    ])
+    ->setFinder($finder); 

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,21 @@
             "email": "adam.wathan@gmail.com"
         }
     ],
+    "require": {
+        "illuminate/container": "^5.6",
+        "illuminate/support": "^5.6",
+        "illuminate/view": "^5.6",
+        "symfony/console": "~3.0|^4.0",
+        "mockery/mockery": "^1.0.0",
+        "mnapoli/front-yaml": "^1.5",
+        "symfony/yaml": "^4.0",
+        "erusev/parsedown-extra": "^0.7.1"
+    },
+    "require-dev": {
+        "mikey179/vfsStream": "^1.6",
+        "phpunit/phpunit": "~7.0",
+        "friendsofphp/php-cs-fixer": "^2.12"
+    },
     "autoload": {
         "psr-4": {
             "TightenCo\\Jigsaw\\": "src/"
@@ -21,22 +36,17 @@
         "psr-4": {
             "Tests\\": "tests/"
         }
-    },
-    "require": {
-        "illuminate/container": "^5.6",
-        "illuminate/support": "^5.6",
-        "illuminate/view": "^5.6",
-        "symfony/console": "~3.0|^4.0",
-        "mockery/mockery": "^1.0.0",
-        "mnapoli/front-yaml": "^1.5",
-        "symfony/yaml": "^4.0",
-        "erusev/parsedown-extra": "^0.7.1"
-    },
+    },        
     "bin": [
         "jigsaw"
     ],
-    "require-dev": {
-        "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "~7.0"
+    "scripts": {
+        "fix" : "php vendor/bin/php-cs-fixer fix --using-cache=no"   
+    },
+    "prefer-stable": true,
+    "config": {
+        "sort-packages": true,
+        "preferred-install": "dist",
+        "optimize-autoloader": true
     }
 }

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Collection;
+<?php
+
+namespace TightenCo\Jigsaw\Collection;
 
 use Closure;
 use Illuminate\Support\Collection as BaseCollection;
@@ -10,7 +12,7 @@ class Collection extends BaseCollection
 
     public static function withSettings($settings, $name)
     {
-        $collection = new static;
+        $collection = new static();
         $collection->settings = $settings;
         $collection->name = $name;
 
@@ -72,9 +74,9 @@ class Collection extends BaseCollection
             $value_2 = $this->getValueForSorting($item_2, array_get($setting, 'key'));
 
             if ($value_1 > $value_2) {
-               return $setting['direction'];
+                return $setting['direction'];
             } elseif ($value_1 < $value_2) {
-               return -$setting['direction'];
+                return -$setting['direction'];
             }
         }
     }

--- a/src/Collection/CollectionItem.php
+++ b/src/Collection/CollectionItem.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Collection;
+<?php
+
+namespace TightenCo\Jigsaw\Collection;
 
 use TightenCo\Jigsaw\PageVariable;
 
@@ -46,11 +48,11 @@ class CollectionItem extends PageVariable
 
     public function __toString()
     {
-        return (String) $this->getContent();
+        return (string) $this->getContent();
     }
 
     protected function missingHelperError($functionName)
     {
-        return 'No function named "' . $functionName. '" for the collection "' . $this->_meta->collectionName . '" was found in the file "config.php".';
+        return 'No function named "' . $functionName . '" for the collection "' . $this->_meta->collectionName . '" was found in the file "config.php".';
     }
 }

--- a/src/Collection/CollectionPaginator.php
+++ b/src/Collection/CollectionPaginator.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Collection;
+<?php
+
+namespace TightenCo\Jigsaw\Collection;
 
 use TightenCo\Jigsaw\IterableObject;
 
@@ -17,6 +19,7 @@ class CollectionPaginator
         $totalPages = $chunked->count();
         $numberedPageLinks = $chunked->map(function ($_, $i) use ($file) {
             $page = $i + 1;
+
             return ['number' => $page, 'path' => $this->getPageLink($file, $page)];
         })->pluck('path', 'number');
 

--- a/src/Collection/CollectionRemoteItem.php
+++ b/src/Collection/CollectionRemoteItem.php
@@ -1,7 +1,8 @@
-<?php namespace TightenCo\Jigsaw\Collection;
+<?php
+
+namespace TightenCo\Jigsaw\Collection;
 
 use Symfony\Component\Yaml\Yaml;
-use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 
 class CollectionRemoteItem
 {

--- a/src/CollectionItemHandlers/BladeCollectionItemHandler.php
+++ b/src/CollectionItemHandlers/BladeCollectionItemHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\CollectionItemHandlers;
+<?php
+
+namespace TightenCo\Jigsaw\CollectionItemHandlers;
 
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 

--- a/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
+++ b/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\CollectionItemHandlers;
+<?php
+
+namespace TightenCo\Jigsaw\CollectionItemHandlers;
 
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Console;
+<?php
+
+namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,8 +22,8 @@ class BuildCommand extends Command
     {
         $this->setName('build')
             ->setDescription('Build your site.')
-            ->addArgument('env', InputArgument::OPTIONAL, "What environment should we use to build?", 'local')
-            ->addOption('pretty', null, InputOption::VALUE_REQUIRED, "Should the site use pretty URLs?", 'true');
+            ->addArgument('env', InputArgument::OPTIONAL, 'What environment should we use to build?', 'local')
+            ->addOption('pretty', null, InputOption::VALUE_REQUIRED, 'Should the site use pretty URLs?', 'true');
     }
 
     protected function fire()
@@ -31,7 +33,7 @@ class BuildCommand extends Command
         $this->updateBuildPaths($env);
 
         if ($this->input->getOption('pretty') === 'true') {
-            $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
+            $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         }
 
         $this->app->make(Jigsaw::class)->build($env);

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Console;
+<?php
+
+namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -11,6 +13,7 @@ abstract class Command extends SymfonyCommand
     {
         $this->input = $input;
         $this->output = $output;
+
         return (int) $this->fire();
     }
 

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Console;
+<?php
+
+namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
 use TightenCo\Jigsaw\File\Filesystem;

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Console;
+<?php
+
+namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/UseCommand.php
+++ b/src/Console/UseCommand.php
@@ -1,7 +1,8 @@
-<?php namespace TightenCo\Jigsaw\Console;
+<?php
+
+namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use TightenCo\Jigsaw\File\Filesystem;
 
 class UseCommand extends Command
@@ -43,8 +44,9 @@ class UseCommand extends Command
     {
         $this->comment("\nThis will replace your current `package.json` file, and any existing Gulp or Webpack configurations.");
 
-        if (! $this->confirm("Do you wish to continue? ")) {
+        if (! $this->confirm('Do you wish to continue? ')) {
             $this->info("\nNo changes were made.\n");
+
             return;
         }
 

--- a/src/Events/EventBus.php
+++ b/src/Events/EventBus.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Events;
+<?php
+
+namespace TightenCo\Jigsaw\Events;
 
 use TightenCo\Jigsaw\Jigsaw;
 

--- a/src/File/BladeDirectivesFile.php
+++ b/src/File/BladeDirectivesFile.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 use Illuminate\View\Compilers\BladeCompiler;
 

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 class ConfigFile
 {
@@ -12,7 +14,7 @@ class ConfigFile
 
     protected function convertStringCollectionsToArray()
     {
-        $collections =  array_get($this->config, 'collections');
+        $collections = array_get($this->config, 'collections');
 
         if ($collections) {
             $this->config['collections'] = collect($collections)->flatMap(function ($value, $key) {

--- a/src/File/CopyFile.php
+++ b/src/File/CopyFile.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 class CopyFile extends OutputFile
 {

--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 use Symfony\Component\Finder\Finder;

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -1,11 +1,13 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 class InputFile
 {
     protected $file;
     protected $basePath;
     protected $extraBladeExtensions = [
-        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html'
+        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
 
     public function __construct($file, $basePath)

--- a/src/File/OutputFile.php
+++ b/src/File/OutputFile.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 class OutputFile
 {

--- a/src/File/TemporaryFilesystem.php
+++ b/src/File/TemporaryFilesystem.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\File;
+<?php
+
+namespace TightenCo\Jigsaw\File;
 
 use Illuminate\Support\Str;
 
@@ -10,7 +12,7 @@ class TemporaryFilesystem
     public function __construct($tempPath, $filesystem = null)
     {
         $this->tempPath = $tempPath;
-        $this->filesystem = $filesystem ?: new Filesystem;
+        $this->filesystem = $filesystem ?: new Filesystem();
     }
 
     public function put($contents, $callback, $extension = '')

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\PageData;
@@ -51,7 +53,7 @@ class BladeHandler
                     $this->renderWithFrontMatter($file, $pageData) :
                     $this->render($file->getPathName(), $pageData),
                 $pageData
-            )
+            ),
         ]);
     }
 

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
 

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\File\CopyFile;
@@ -26,7 +28,7 @@ class DefaultHandler
                 $file->getBasename('.' . $file->getExtension()),
                 $file->getExtension(),
                 $pageData
-            )
+            ),
         ];
     }
 }

--- a/src/Handlers/IgnoredHandler.php
+++ b/src/Handlers/IgnoredHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 class IgnoredHandler
 {

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\PageData;
@@ -75,13 +77,13 @@ class MarkdownHandler
 
     private function getEscapedMarkdownContent($file)
     {
-        $replacements = ["<?php" => "<{{'?php'}}"];
+        $replacements = ['<?php' => "<{{'?php'}}"];
 
         if (in_array($file->getFullExtension(), ['markdown', 'md', 'mdown'])) {
             $replacements = array_merge([
-                "@" => "{{'@'}}",
-                "{{" => "@{{",
-                "{!!" => "@{!!",
+                '@' => "{{'@'}}",
+                '{{' => '@{{',
+                '{!!' => '@{!!',
             ], $replacements);
         }
 

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Handlers;
+<?php
+
+namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
 use TightenCo\Jigsaw\PageData;

--- a/src/IterableObject.php
+++ b/src/IterableObject.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 use ArrayAccess;
 use Exception;
@@ -28,7 +30,7 @@ class IterableObject extends BaseCollection implements ArrayAccess
     public function offsetGet($key)
     {
         if (! isset($this->items[$key])) {
-            $prefix = $this->_source ? 'Error in ' . $this->_source . ': '  : 'Error: ';
+            $prefix = $this->_source ? 'Error in ' . $this->_source . ': ' : 'Error: ';
             throw new Exception($prefix . "The key '$key' does not exist.");
         }
 

--- a/src/IterableObjectWithDefault.php
+++ b/src/IterableObjectWithDefault.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 class IterableObjectWithDefault extends IterableObject
 {

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
 

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Loaders;
+<?php
+
+namespace TightenCo\Jigsaw\Loaders;
 
 use Exception;
 use TightenCo\Jigsaw\Collection\Collection;

--- a/src/Loaders/CollectionRemoteItemLoader.php
+++ b/src/Loaders/CollectionRemoteItemLoader.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Loaders;
+<?php
+
+namespace TightenCo\Jigsaw\Loaders;
 
 use TightenCo\Jigsaw\Collection\CollectionRemoteItem;
 use TightenCo\Jigsaw\File\Filesystem;

--- a/src/Loaders/DataLoader.php
+++ b/src/Loaders/DataLoader.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Loaders;
+<?php
+
+namespace TightenCo\Jigsaw\Loaders;
 
 use TightenCo\Jigsaw\SiteData;
 

--- a/src/PageData.php
+++ b/src/PageData.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 class PageData extends IterableObject
 {

--- a/src/PageVariable.php
+++ b/src/PageVariable.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 class PageVariable extends IterableObject
 {
@@ -30,7 +32,7 @@ class PageVariable extends IterableObject
             return $this->_meta->path->get($key ?: $this->getExtending());
         }
 
-        return (String) $this->_meta->path;
+        return (string) $this->_meta->path;
     }
 
     public function getPaths()
@@ -44,7 +46,7 @@ class PageVariable extends IterableObject
             return $this->_meta->url->get($key ?: $this->getExtending());
         }
 
-        return (String) $this->_meta->url;
+        return (string) $this->_meta->url;
     }
 
     public function getUrls()

--- a/src/Parsers/FrontMatterParser.php
+++ b/src/Parsers/FrontMatterParser.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Parsers;
+<?php
+
+namespace TightenCo\Jigsaw\Parsers;
 
 use Mni\FrontYAML\Parser;
 
@@ -43,7 +45,7 @@ class FrontMatterParser
         $extendsFromFrontMatter = array_get($parsed->frontMatter, 'extends');
 
         return (! $this->getExtendsFromBladeContent($parsed->content) && $extendsFromFrontMatter) ?
-            $this->addExtendsToBladeContent($extendsFromFrontMatter, $parsed->content):
+            $this->addExtendsToBladeContent($extendsFromFrontMatter, $parsed->content) :
             $parsed->content;
     }
 

--- a/src/Parsers/ParsedownExtraParser.php
+++ b/src/Parsers/ParsedownExtraParser.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\Parsers;
+<?php
+
+namespace TightenCo\Jigsaw\Parsers;
 
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use ParsedownExtra;

--- a/src/PathResolvers/BasicOutputPathResolver.php
+++ b/src/PathResolvers/BasicOutputPathResolver.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\PathResolvers;
+<?php
+
+namespace TightenCo\Jigsaw\PathResolvers;
 
 class BasicOutputPathResolver
 {

--- a/src/PathResolvers/CollectionPathResolver.php
+++ b/src/PathResolvers/CollectionPathResolver.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\PathResolvers;
+<?php
+
+namespace TightenCo\Jigsaw\PathResolvers;
 
 use TightenCo\Jigsaw\IterableObject;
 
@@ -142,19 +144,19 @@ class CollectionPathResolver
 
         // Convert all dashes/underscores into separator
         $flip = $separator == '-' ? '_' : '-';
-        $string = preg_replace('!['.preg_quote($flip).']+!u', $separator, $string);
+        $string = preg_replace('![' . preg_quote($flip) . ']+!u', $separator, $string);
 
         // Remove all characters that are not the separator, letters, numbers, whitespace, or dot
-        $string = preg_replace('![^'.preg_quote($separator).'\pL\pN\s\.]+!u', '', mb_strtolower($string));
+        $string = preg_replace('![^' . preg_quote($separator) . '\pL\pN\s\.]+!u', '', mb_strtolower($string));
 
         // Replace all separator characters and whitespace by a single separator
-        $string = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $string);
+        $string = preg_replace('![' . preg_quote($separator) . '\s]+!u', $separator, $string);
 
         return trim($string, $separator);
     }
 
     /**
-     * Filter characters that are invalid in URL, like ® and ™, allowing spaces
+     * Filter characters that are invalid in URL, like ® and ™, allowing spaces.
      */
     private function filterInvalidCharacters($value)
     {

--- a/src/PathResolvers/PrettyOutputPathResolver.php
+++ b/src/PathResolvers/PrettyOutputPathResolver.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\PathResolvers;
+<?php
+
+namespace TightenCo\Jigsaw\PathResolvers;
 
 class PrettyOutputPathResolver
 {
@@ -8,6 +10,7 @@ class PrettyOutputPathResolver
             if ($page > 1) {
                 return '/' . leftTrimPath(trimPath($path) . '/') . $page . '/';
             }
+
             return  leftTrimPath('/' . trimPath($path) . '/') . '/';
         }
 
@@ -15,6 +18,7 @@ class PrettyOutputPathResolver
             if ($page > 1) {
                 return '/' . leftTrimPath(trimPath($path) . '/') . $name . '/' . $page . '/';
             }
+
             return '/' . leftTrimPath(trimPath($path) . '/') . $name . '/';
         }
 
@@ -31,6 +35,7 @@ class PrettyOutputPathResolver
             if ($page > 1) {
                 return  trimPath($path) . '/' . $name . '/' . $page . '/' . 'index.html';
             }
+
             return trimPath($path) . '/' . $name . '/' . 'index.html';
         }
 
@@ -51,6 +56,7 @@ class PrettyOutputPathResolver
             if ($page > 1) {
                 return  trimPath($path) . '/' . $name . '/' . $page;
             }
+
             return trimPath($path) . '/' . $name;
         }
 

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\File\InputFile;
@@ -115,7 +117,10 @@ class SiteBuilder
         }
 
         return resolvePath(urldecode($this->outputPathResolver->path(
-            $file->path(), $file->name(), $file->extension(), $file->page()
+            $file->path(),
+            $file->name(),
+            $file->extension(),
+            $file->page()
         )));
     }
 
@@ -126,12 +131,15 @@ class SiteBuilder
         }
 
         return rightTrimPath(urldecode($this->outputPathResolver->link(
-            $file->path(), $file->name(), $file->extension(), $file->page()
+            $file->path(),
+            $file->name(),
+            $file->extension(),
+            $file->page()
         )));
     }
 
     private function getFilePermalink($file)
     {
-        return $file->data()->page->permalink ? resolvePath(urldecode($file->data()->page->permalink)) : NULL;
+        return $file->data()->page->permalink ? resolvePath(urldecode($file->data()->page->permalink)) : null;
     }
 }

--- a/src/SiteData.php
+++ b/src/SiteData.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw;
+<?php
+
+namespace TightenCo\Jigsaw;
 
 class SiteData extends IterableObject
 {

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -9,12 +9,12 @@ use Illuminate\Support\Str;
  */
 function leftTrimPath($path)
 {
-    return ltrim($path, " .\\/");
+    return ltrim($path, ' .\\/');
 }
 
 function rightTrimPath($path)
 {
-    return rtrim($path, " .\\/");
+    return rtrim($path, ' .\\/');
 }
 
 function trimPath($path)
@@ -24,13 +24,13 @@ function trimPath($path)
 
 function resolvePath($path)
 {
-    $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $path);
+    $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
     $segments = [];
 
     collect(explode(DIRECTORY_SEPARATOR, $path))->filter()->each(function ($part) use (&$segments) {
         if ($part == '..') {
             array_pop($segments);
-        } elseif  ($part != '.') {
+        } elseif ($part != '.') {
             $segments[] = $part;
         }
     });
@@ -82,11 +82,11 @@ function mix($path, $manifestDirectory = 'assets')
         $manifestDirectory = "/{$manifestDirectory}";
     }
 
-    if (file_exists(public_path($manifestDirectory.'/hot'))) {
+    if (file_exists(public_path($manifestDirectory . '/hot'))) {
         return new HtmlString("//localhost:8080{$path}");
     }
 
-    $manifestPath = public_path($manifestDirectory.'/mix-manifest.json');
+    $manifestPath = public_path($manifestDirectory . '/mix-manifest.json');
 
     if (! isset($manifests[$manifestPath])) {
         if (! file_exists($manifestPath)) {
@@ -102,5 +102,5 @@ function mix($path, $manifestDirectory = 'assets')
         throw new InvalidArgumentException("Unable to locate Mix file: {$path}.");
     }
 
-    return new HtmlString($manifestDirectory.$manifest[$path]);
+    return new HtmlString($manifestDirectory . $manifest[$path]);
 }

--- a/src/View/BladeMarkdownEngine.php
+++ b/src/View/BladeMarkdownEngine.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\View;
+<?php
+
+namespace TightenCo\Jigsaw\View;
 
 use Exception;
 use Illuminate\Contracts\View\Engine as EngineInterface;

--- a/src/View/MarkdownEngine.php
+++ b/src/View/MarkdownEngine.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\View;
+<?php
+
+namespace TightenCo\Jigsaw\View;
 
 use Exception;
 use Illuminate\Contracts\View\Engine as EngineInterface;

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -1,4 +1,6 @@
-<?php namespace TightenCo\Jigsaw\View;
+<?php
+
+namespace TightenCo\Jigsaw\View;
 
 use Illuminate\View\Factory;
 
@@ -14,7 +16,7 @@ class ViewRenderer
         'blade.markdown' => 'blade-markdown',
     ];
     private $bladeExtensions = [
-        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html'
+        'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
 
     public function __construct(Factory $viewFactory)

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests;
 
-use TightenCo\Jigsaw\Jigsaw;
-use TightenCo\Jigsaw\SiteBuilder;
-use org\bovigo\vfs\vfsStream;
-
 class CollectionItemTest extends TestCase
 {
     public function test_collection_item_contents_are_returned_when_item_is_referenced_as_a_string()

--- a/tests/DotInFileNameTest.php
+++ b/tests/DotInFileNameTest.php
@@ -50,7 +50,7 @@ class DotInFileNameTest extends TestCase
 
     public function test_dot_in_filename_is_preserved_for_collection_item_with_default_path_config()
     {
-        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         $pathResolver = $this->app->make(CollectionPathResolver::class);
         $pageVariable = $this->getPageVariableDummy('collection-item-with.dot');
         $outputPath = $pathResolver->link(null, $pageVariable);
@@ -60,7 +60,7 @@ class DotInFileNameTest extends TestCase
 
     public function test_dot_in_filename_is_preserved_for_collection_item_with_shorthand_path_config()
     {
-        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         $pathResolver = $this->app->make(CollectionPathResolver::class);
         $pageVariable = $this->getPageVariableDummy('collection-item-with.dot');
         $outputPath = $pathResolver->link('{filename}', $pageVariable);
@@ -70,7 +70,7 @@ class DotInFileNameTest extends TestCase
 
     public function test_dot_in_filename_is_preserved_for_collection_item_with_slugified_shorthand_path_config()
     {
-        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver);
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         $pathResolver = $this->app->make(CollectionPathResolver::class);
         $pageVariable = $this->getPageVariableDummy('collection-item-with.dot');
         $outputPath = $pathResolver->link('{_filename}', $pageVariable);

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use TightenCo\Jigsaw\Jigsaw;
 use org\bovigo\vfs\vfsStream;
 
 class EventsTest extends TestCase
@@ -150,7 +149,7 @@ class EventsTest extends TestCase
         });
         $this->buildSite($this->setupSource(), [
             'test_variable' => [
-                'nested' => 'original value'
+                'nested' => 'original value',
             ],
         ]);
 
@@ -396,7 +395,7 @@ class EventsTest extends TestCase
         });
         $this->buildSite($source = $this->setupSource([
             'test' => [
-                'file.blade.php' => '<h1>test</h1>'
+                'file.blade.php' => '<h1>test</h1>',
             ],
         ]));
 
@@ -421,7 +420,7 @@ class EventsTest extends TestCase
         });
         $this->buildSite($source = $this->setupSource([
             'test' => [
-                'file.blade.php' => '<h1>test</h1>'
+                'file.blade.php' => '<h1>test</h1>',
             ],
         ]));
 

--- a/tests/IterableObjectTest.php
+++ b/tests/IterableObjectTest.php
@@ -3,9 +3,6 @@
 namespace Tests;
 
 use TightenCo\Jigsaw\IterableObject;
-use TightenCo\Jigsaw\Jigsaw;
-use TightenCo\Jigsaw\SiteBuilder;
-use org\bovigo\vfs\vfsStream;
 
 class IterableObjectTest extends TestCase
 {
@@ -148,5 +145,4 @@ class IterableObjectTest extends TestCase
 
 class ExtendsIterableObject extends IterableObject
 {
-    //
 }

--- a/tests/MarkdownExtraTest.php
+++ b/tests/MarkdownExtraTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests;
 
-use TightenCo\Jigsaw\Handlers\MarkdownHandler;
-use TightenCo\Jigsaw\IterableObject;
-use TightenCo\Jigsaw\PageData;
-
 class MarkdownExtraTest extends TestCase
 {
     public function test_parse_markdown_inside_html_blocks()

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -2,10 +2,6 @@
 
 namespace Tests;
 
-use TightenCo\Jigsaw\Jigsaw;
-use TightenCo\Jigsaw\Loaders\DataLoader;
-use org\bovigo\vfs\vfsStream;
-
 class RemoteCollectionsTest extends TestCase
 {
     public function test_collection_does_not_require_matching_source_directory()
@@ -225,7 +221,7 @@ class RemoteCollectionsTest extends TestCase
                         [
                             'extends' => '_layouts.master',
                             'content' => 'item content',
-                            'variable' => 'page variable'
+                            'variable' => 'page variable',
                         ],
                     ],
                 ],
@@ -277,7 +273,7 @@ class RemoteCollectionsTest extends TestCase
             'collections' => [
                 'test' => [
                     'extends' => '_layouts.master',
-                    'items' => [ '## item content' ],
+                    'items' => ['## item content'],
                 ],
             ],
         ]);
@@ -386,7 +382,7 @@ class RemoteCollectionsTest extends TestCase
             'collections' => [
                 'test' => [
                     'extends' => '_layouts.master',
-                    'items' => function() {
+                    'items' => function () {
                         return [
                             ['content' => 'item 1'],
                             ['content' => 'item 2'],
@@ -418,7 +414,7 @@ class RemoteCollectionsTest extends TestCase
             'collections' => [
                 'test' => [
                     'extends' => '_layouts.master',
-                    'items' => function() {
+                    'items' => function () {
                         return collect([
                             ['content' => 'item 1'],
                             ['content' => 'item 2'],
@@ -450,11 +446,11 @@ class RemoteCollectionsTest extends TestCase
             'collections' => [
                 'test' => [
                     'extends' => '_layouts.master',
-                    'items' => function() {
+                    'items' => function () {
                         $remote_post = json_decode(file_get_contents('https://jsonplaceholder.typicode.com/posts/1'));
 
                         return [
-                            ['content' => $remote_post->body ],
+                            ['content' => $remote_post->body],
                         ];
                     },
                 ],

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -12,7 +12,7 @@ class SnapshotTest extends SnapshotTestCase
     public function test_all_built_files_contain_expected_content()
     {
         collect($this->build_files)->each(function ($file) {
-            echo("\r\nChecking " . $file->getRelativePathname());
+            echo "\r\nChecking " . $file->getRelativePathname();
             $this->assertEquals(
                 file_get_contents('tests/snapshots/' . $file->getRelativePathname()),
                 $file->getContents(),
@@ -21,12 +21,12 @@ class SnapshotTest extends SnapshotTestCase
         });
 
         $this->echoLine();
-        echo("\r\n√ All built files pass.");
+        echo "\r\n√ All built files pass.";
         $this->echoLine();
     }
 
     protected function echoLine()
     {
-        echo("\r\n-----------------------");
+        echo "\r\n-----------------------";
     }
 }

--- a/tests/SnapshotTestCase.php
+++ b/tests/SnapshotTestCase.php
@@ -23,7 +23,7 @@ class SnapshotTestCase extends BaseTestCase
     public static function tearDownAfterClass()
     {
         if (self::DELETE_BUILT_FILES) {
-            (new Filesystem)->deleteDirectory('tests/build-testing');
+            (new Filesystem())->deleteDirectory('tests/build-testing');
         }
 
         parent::tearDownAfterClass();
@@ -32,7 +32,7 @@ class SnapshotTestCase extends BaseTestCase
     public function setUp()
     {
         try {
-            $this->filesystem = new Filesystem;
+            $this->filesystem = new Filesystem();
             $this->build_files = $this->filesystem->allFiles('tests/build-testing');
         } catch (\Exception $e) {
             die("Error: Jigsaw test site was not built.\r\n");

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,13 +20,13 @@ class TestCase extends BaseTestCase
     public function setUp()
     {
         parent::setUp();
-        require('jigsaw-core.php');
+        require 'jigsaw-core.php';
         $this->app = $container;
         $this->app->buildPath = [
             'source' => $this->sourcePath,
             'destination' => $this->destinationPath,
         ];
-        $this->filesystem = new Filesystem;
+        $this->filesystem = new Filesystem();
         $this->tempPath = $cachePath;
         $this->prepareTempDirectory();
     }

--- a/tests/config.php
+++ b/tests/config.php
@@ -7,7 +7,7 @@ return [
         'destination' => 'tests/build-testing',
     ],
     'baseUrl' => 'http://jigsaw-test.dev',
-    'global_array' => [ 1, 2, 3 ],
+    'global_array' => [1, 2, 3],
     'global_variable' => 'some global variable',
     'number' => '98765',
     'perPage' => 4,
@@ -81,6 +81,7 @@ return [
             'author' => 'Default Author',
             'date_formatted' => function ($post) {
                 list($year, $month, $day) = parseDate($post['date']);
+
                 return sprintf('%s/%s/%s', $month, $day, $year);
             },
             'preview' => function ($post, $characters = 75) {
@@ -104,7 +105,7 @@ return [
             'path' => [
                 'web' => 'people/web/{date|Y-m-d}/{_filename}',
                 'test' => 'people/test/{-filename}',
-                'api' => 'people/api.test/{name}/{date|Y-m-d}/{-name}'
+                'api' => 'people/api.test/{name}/{date|Y-m-d}/{-name}',
             ],
             'number_doubled' => function ($data) {
                 return $data->number * 2;

--- a/tests/rebuild.php
+++ b/tests/rebuild.php
@@ -14,7 +14,7 @@ function removeDirectory($path)
         exit("Path to the 'tests/snapshots' directory is missing");
     }
 
-    $files = glob($path . '/{,.}[!.,!..]*', GLOB_MARK|GLOB_BRACE);
+    $files = glob($path . '/{,.}[!.,!..]*', GLOB_MARK | GLOB_BRACE);
 
     foreach ($files as $file) {
         is_dir($file) ? removeDirectory($file) : unlink($file);


### PR DESCRIPTION
Using PHP CS Fixer we can provide some guidelines to show how the code should be formatted, this way running a simple command `composer run fix` would make it easier to fix.

The rules which I've set within the `.php_cs` file is based on the following comment https://github.com/tightenco/jigsaw/pull/242#issuecomment-410484789 