### PR TITLE
Use secure links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Simple static sites with Laravel's [Blade](https://laravel.com/docs/blade).
 
-For documentation, visit http://jigsaw.tighten.co/docs/installation/
+For documentation, visit https://jigsaw.tighten.co/docs/installation/
 
 ---
 
@@ -12,5 +12,5 @@ __Version 1.0 includes a change to the way site variables are referenced in your
 
 Site variables defined in `config.php`, as well as any variables defined in the YAML front matter of a page, are now accessible under the `$page` object, rather than by referencing the variable name itself. Blade templates that include variables will need to be updated so that all variables are prefixed with `$page->`.
 
-Check out http://jigsaw.tighten.co/docs/upgrading/ for an example.
+Check out https://jigsaw.tighten.co/docs/upgrading/ for an example.
 


### PR DESCRIPTION
The site appears to support HTTPS, but it doesn't redirect there. Lets link to the secure variant by default 🙂 