### PR TITLE
Added `isMarkdown()` method to `PageVariable` class

### DIFF
--- a/src/PageVariable.php
+++ b/src/PageVariable.php
@@ -54,6 +54,11 @@ class PageVariable extends IterableObject
         return $this->_meta->url;
     }
 
+    public function isMarkdown()
+    {
+        return in_array($this->getExtension(), ['markdown', 'md', 'mdown']);
+    }
+
     protected function missingHelperError($functionName)
     {
         return 'No function named "' . $functionName . '" was found in the file "config.php".';


### PR DESCRIPTION
This PR adds an `isMarkdown()` method in the `PageVariable` class.

___

The number one purpose of this method is to be used with `getContent`.

The docs state that `getContent()` *is available for Markdown files only*.

This method will help in situations where you need to determine if `getContent()` is usable on certain pages. Specifically when the relevant code is in a layout that may be used by both blade and markdown files (like the `master.blade.php` layout).

___

Besides the specific purpose mentioned above, this method can have many uses considering that a SSG will likely contain tons of markdown files.

___

My usage:

```html
<meta name="description" content="{!! $page->isMarkdown() ? $page->excerpt() : $page->description !!}">
<meta property="og:description" content="{!! $page->isMarkdown() ? $page->excerpt() : $page->description !!}">
<meta property="og:type" content="{{ $page->isMarkdown() ? 'article' : 'website' }}">
<meta name="twitter:description" content="{!! $page->isMarkdown() ? $page->excerpt() : $page->description !!}">
```

Please also see [issue 251](https://github.com/tightenco/jigsaw/issues/251) which is related to this snippet