### PR TITLE
Added production config stub

### DIFF
--- a/stubs/mix/package.json
+++ b/stubs/mix/package.json
@@ -5,6 +5,7 @@
         "staging": "cross-env NODE_ENV=staging node_modules/webpack/bin/webpack.js --progress --hide-modules --env=staging --config=node_modules/laravel-mix/setup/webpack.config.js",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --env=production --config=node_modules/laravel-mix/setup/webpack.config.js",
         "dev": "npm run local",
+        "prod": "npm run production",
         "watch": "npm run local -- --watch"
     },
     "devDependencies": {

--- a/stubs/site/config.php
+++ b/stubs/site/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'baseUrl' => '',
     'production' => false,
+    'baseUrl' => '',
     'collections' => [],
 ];

--- a/stubs/site/config.production.php
+++ b/stubs/site/config.production.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'production' => true,
+];


### PR DESCRIPTION
This PR adds a `config.production.php` stub.

___

The default `config.php` file contains a `production` key but it is always set to `false`.

When the user runs `npm run production` the value of this key remains false (unless they remember to add the prod config file) which may lead to unexpected behavior when they use that config key in their code.

___

**Details of changes:**

- I added a new stub that contains `'production' => true,`
- In `config.php` I moved the `production` key to the top so that it lines up with the new stub
- Since the `local` script in `package.json` is aliased to `dev`, I aliased `production` to `prod` (exactly like Laravel's npm scripts)

