### PR TITLE
Updated gitignore stub (different from PR 215)

### DIFF
--- a/stubs/site/.gitignore
+++ b/stubs/site/.gitignore
@@ -1,3 +1,14 @@
 /build_local/
 /node_modules/
 /vendor/
+/.idea/
+/.vscode/
+npm-debug.log
+yarn-error.log
+
+# Optional ignores
+# /build_staging/
+# /build_production/
+# /source/assets/build/css/
+# /source/assets/build/fonts/
+# /source/assets/build/js/


### PR DESCRIPTION
I'm submitting this PR because tightenco/jigsaw#215 seems to have been forgotten, the person who made it didn't reply to my comment, and I have different changes from that one.

___

- I tried to keep the simplicity of the file by not changing much of how it looks.
- I referenced [Laravel's current gitignore](https://github.com/laravel/laravel/blob/289b1457317a08813b8998a9a225535926bd90ee/.gitignore) and picked out the ones that can also apply to Jigsaw.
- I added the staging and production folders and compiled assets as optional ignores in comments

I'm not sure about the the staging and production folders being optional though, **I feel like they should be ignored by default**.