### PR TITLE
Added SEO tags to master.blade.php stub

### DIFF
--- a/stubs/site/config.php
+++ b/stubs/site/config.php
@@ -3,5 +3,7 @@
 return [
     'production' => false,
     'baseUrl' => '',
+    'title' => 'Jigsaw',
+    'description' => 'Website description.',
     'collections' => [],
 ];

--- a/stubs/site/source/_layouts/master.blade.php
+++ b/stubs/site/source/_layouts/master.blade.php
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ $page->language ?? 'en' }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <meta name="referrer" content="always">
+        <link rel="canonical" href="{{ $page->getUrl() }}">
+        <meta name="description" content="{{ $page->description }}">
+        <title>{{ $page->title }}</title>
         <link rel="stylesheet" href="{{ mix('css/main.css', 'assets/build') }}">
     </head>
     <body>


### PR DESCRIPTION
I'm reviving another old/dead PR tightenco/jigsaw#167 by someone else.

Keith seemed to be interested in merging it but the PR author never responded to the requested changes.

**Differences from the other PR**

- I didn't add keywords
- I didn't add the `language` key in the config. PHP null coalesce does an `isset()` behind the scenes which will return true even for `''`. `'language' => 'en',` is redundant and `'language' => '',` would cause unintended behavior.
- I added `<link rel="canonical" href="{{ $page->getUrl() }}">` and `<meta name="referrer" content="always">`
- I didn't add YAML front matter to `source/index.blade.php`

Additional note: I added the new config keys *before* `collections` because `title` and `description` are just one-line config keys while `collections` can potentially grow into a large array. It also makes more sense for them to be after/adjacent to `baseUrl` as they're all general details about the site.