### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 .DS_Store
 composer.lock
+.phpunit.result.cache
 _tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+/cache
 /vendor
 .DS_Store
 composer.lock
 .phpunit.result.cache
-_tmp/

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "illuminate/support": "^5.6",
         "illuminate/view": "^5.6",
         "symfony/console": "~3.0|^4.0",
-        "mockery/mockery": "^1.0.0",
         "mnapoli/front-yaml": "^1.5",
         "symfony/yaml": "^4.0",
         "erusev/parsedown-extra": "^0.7.1"
@@ -36,12 +35,12 @@
         "psr-4": {
             "Tests\\": "tests/"
         }
-    },        
+    },
     "bin": [
         "jigsaw"
     ],
     "scripts": {
-        "fix" : "php vendor/bin/php-cs-fixer fix --using-cache=no"   
+        "fix" : "php vendor/bin/php-cs-fixer fix --using-cache=no"
     },
     "prefer-stable": true,
     "config": {

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -12,10 +12,11 @@ use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 use Mni\FrontYAML\Parser;
 use Mni\FrontYAML\YAML\YAMLParser;
-use TightenCo\Jigsaw\Collection\CollectionPaginator;
 use TightenCo\Jigsaw\CollectionItemHandlers\BladeCollectionItemHandler;
 use TightenCo\Jigsaw\CollectionItemHandlers\MarkdownCollectionItemHandler;
+use TightenCo\Jigsaw\Collection\CollectionPaginator;
 use TightenCo\Jigsaw\Events\EventBus;
+use TightenCo\Jigsaw\Events\FakeDispatcher;
 use TightenCo\Jigsaw\File\BladeDirectivesFile;
 use TightenCo\Jigsaw\File\ConfigFile;
 use TightenCo\Jigsaw\File\Filesystem;
@@ -105,7 +106,7 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
 
     $finder = new FileViewFinder(new Filesystem, [$cachePath, $c['buildPath']['source']]);
 
-    return new Factory($resolver, $finder, Mockery::mock(Dispatcher::class)->shouldIgnoreMissing());
+    return new Factory($resolver, $finder, new FakeDispatcher());
 });
 
 $container->bind(ViewRenderer::class, function ($c) {

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -80,10 +80,11 @@ $container->bind(FrontMatterParser::class, function ($c) {
     return new FrontMatterParser($c[Parser::class]);
 });
 
-$container->bind(Factory::class, function ($c) use ($cachePath) {
+$bladeCompiler = new BladeCompiler(new Filesystem, $cachePath);
+
+$container->bind(Factory::class, function ($c) use ($cachePath, $bladeCompiler) {
     $resolver = new EngineResolver;
 
-    $bladeCompiler = new BladeCompiler(new Filesystem, $cachePath);
     $compilerEngine = new CompilerEngine($bladeCompiler, new Filesystem);
 
     $resolver->register('blade', function () use ($compilerEngine) {
@@ -109,8 +110,8 @@ $container->bind(Factory::class, function ($c) use ($cachePath) {
     return new Factory($resolver, $finder, new FakeDispatcher());
 });
 
-$container->bind(ViewRenderer::class, function ($c) {
-    return new ViewRenderer($c[Factory::class]);
+$container->bind(ViewRenderer::class, function ($c) use ($bladeCompiler) {
+    return new ViewRenderer($c[Factory::class], $bladeCompiler);
 });
 
 $container->bind(BladeHandler::class, function ($c) {

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -52,7 +52,7 @@ $container = new Container;
 
 $container->instance('cwd', getcwd());
 
-$cachePath = $container['cwd'] . '/_tmp';
+$cachePath = $container['cwd'] . '/cache';
 $bootstrapFile = $container['cwd'] . '/bootstrap.php';
 
 $container->instance('buildPath', [

--- a/src/Collection/CollectionItem.php
+++ b/src/Collection/CollectionItem.php
@@ -43,7 +43,9 @@ class CollectionItem extends PageVariable
 
     public function getContent()
     {
-        return $this->_content;
+        return is_callable($this->_content) ?
+            call_user_func($this->_content) :
+            $this->_content;
     }
 
     public function __toString()

--- a/src/CollectionItemHandlers/BladeCollectionItemHandler.php
+++ b/src/CollectionItemHandlers/BladeCollectionItemHandler.php
@@ -34,9 +34,4 @@ class BladeCollectionItemHandler
     {
         return;
     }
-
-    private function getCollectionName($file)
-    {
-        return substr($file->topLevelDirectory(), 1);
-    }
 }

--- a/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
+++ b/src/CollectionItemHandlers/MarkdownCollectionItemHandler.php
@@ -25,6 +25,8 @@ class MarkdownCollectionItemHandler
 
     public function getItemContent($file)
     {
-        return $this->parser->parseMarkdown($file->getContents())->content;
+        return function () use ($file) {
+            return $this->parser->parseMarkdown($file->getContents());
+        };
     }
 }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -23,7 +23,8 @@ class BuildCommand extends Command
         $this->setName('build')
             ->setDescription('Build your site.')
             ->addArgument('env', InputArgument::OPTIONAL, 'What environment should we use to build?', 'local')
-            ->addOption('pretty', null, InputOption::VALUE_REQUIRED, 'Should the site use pretty URLs?', 'true');
+            ->addOption('pretty', null, InputOption::VALUE_REQUIRED, 'Should the site use pretty URLs?', 'true')
+            ->addOption('cache', 'c', InputOption::VALUE_OPTIONAL, 'Should a cache be used when building the site?', 'false');
     }
 
     protected function fire()
@@ -43,12 +44,20 @@ class BuildCommand extends Command
             $jigsaw->setVerbose(false);
         }
 
-        $this->comment('Building ' . $env . ' environment');
+        $this->comment(
+            'Building ' . $env . ' environment' .
+            ($this->useCache() ? ' (caching is on)' : '')
+        );
 
-        $jigsaw->build($env);
+        $jigsaw->build($env, $this->useCache());
 
         $this->comment('Build time: ' .  round(microtime(true) - $startTime, 2) . ' seconds');
         $this->info('Site built successfully!');
+    }
+
+    private function useCache()
+    {
+        return $this->input->getOption('cache') !== 'false' || $this->app->config->get('cache');
     }
 
     private function includeEnvironmentConfig($env)

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -45,7 +45,7 @@ class BuildCommand extends Command
 
         if ($this->input->getOption('quiet')) {
             $verbosity = OutputInterface::VERBOSITY_QUIET;
-        } else if ($this->input->getOption('verbose')) {
+        } elseif ($this->input->getOption('verbose')) {
             $verbosity = OutputInterface::VERBOSITY_VERBOSE;
         } else {
             $verbosity = OutputInterface::VERBOSITY_NORMAL;

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -28,6 +28,7 @@ class BuildCommand extends Command
 
     protected function fire()
     {
+        $startTime = microtime(true);
         $env = $this->input->getArgument('env');
         $this->includeEnvironmentConfig($env);
         $this->updateBuildPaths($env);
@@ -36,7 +37,17 @@ class BuildCommand extends Command
             $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
         }
 
-        $this->app->make(Jigsaw::class)->build($env);
+        $jigsaw = $this->app->make(Jigsaw::class);
+
+        if ($this->input->getOption('quiet')) {
+            $jigsaw->setVerbose(false);
+        }
+
+        $this->comment('Building ' . $env . ' environment');
+
+        $jigsaw->build($env);
+
+        $this->comment('Build time: ' .  round(microtime(true) - $startTime, 2) . ' seconds');
         $this->info('Site built successfully!');
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -52,7 +52,7 @@ class BuildCommand extends Command
         }
 
         $this->consoleOutput->setup($verbosity);
-        $this->consoleOutput->writeIntro($env, $this->useCache());
+        $this->consoleOutput->writeIntro($env, $this->useCache(), $cacheExists);
 
         $this->app->make(Jigsaw::class)->build($env, $this->useCache());
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace TightenCo\Jigsaw\Console;
+
+use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
+
+class ConsoleOutput extends SymfonyConsoleOutput
+{
+    protected $progressBars;
+    protected $sections;
+
+    public function setup($verbosity)
+    {
+        $this->setVerbosity($verbosity);
+        $this->setupSections();
+        $this->setupProgressBars();
+    }
+
+    protected function setupSections()
+    {
+        $this->sections = collect([
+            'footer' => $this->section(),
+            'intro' => $this->section(),
+            'message' => $this->section(),
+            'progress' => $this->section(),
+            'header' => $this->section(),
+        ])->map(function ($section){
+            return $this->section();
+        });
+
+        $this->sections['header']->writeln('');
+        $this->sections['footer']->writeln('');
+    }
+
+    protected function setupProgressBars()
+    {
+        $this->progressBars = [
+            'collections' => $this->getProgressBar('Loading collections...'),
+            'build' => $this->getProgressBar('Building files from source...'),
+        ];
+    }
+
+    protected function getProgressBar($message = null)
+    {
+        return $this->isVerbose() ?
+            new ProgressBar($this, $message, $this->sections['progress']) :
+            new NullProgressBar($this, $message, $this->sections['progress']);
+    }
+
+    public function progressBar($name)
+    {
+        return $this->progressBars[$name];
+    }
+
+    public function startProgressBar($name, $steps = null)
+    {
+        $this->sections['progress']->clear();
+        $progressBar = $this->progressBar($name);
+
+        if ($progressBar->getMessage()) {
+            $this->sections['message']->overwrite($progressBar->getMessage());
+        }
+
+        $progressBar->addSteps($steps)->start();
+    }
+
+    public function writeIntro($env, $useCache)
+    {
+        $this->sections['intro']->overwrite(
+            '<fg=green>Building ' . $env . ' site' .
+            ($useCache ? ' (caching is on)</>' : '</>')
+        );
+
+        return $this;
+    }
+
+    public function writeWritingFiles()
+    {
+        $this->sections['progress']->clear();
+        $this->sections['message']->overwrite('<fg=yellow>Writing files to destination...</>');
+
+        return $this;
+    }
+
+    public function writeTime($time, $useCache = false, $cacheExisted = false)
+    {
+        if ($useCache) {
+            if ($cacheExisted) {
+                $cacheMessage = '(using cache)';
+            } else {
+                $cacheMessage = '(cache was created)';
+            }
+        } else {
+            $cacheMessage = '';
+        }
+
+        $this->sections['intro']->overwrite(
+            '<fg=yellow>Build time: </><fg=white>' .
+            $time .
+            ' seconds</> ' .
+            $cacheMessage
+        );
+
+        return $this;
+    }
+
+    public function writeConclusion()
+    {
+        $this->sections['message']->overwrite('<fg=green>Site build successfully!</>');
+
+        return $this;
+    }
+}

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -24,7 +24,7 @@ class ConsoleOutput extends SymfonyConsoleOutput
             'message' => $this->section(),
             'progress' => $this->section(),
             'header' => $this->section(),
-        ])->map(function ($section){
+        ])->map(function ($section) {
             return $this->section();
         });
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -64,11 +64,24 @@ class ConsoleOutput extends SymfonyConsoleOutput
         $progressBar->addSteps($steps)->start();
     }
 
-    public function writeIntro($env, $useCache)
+    public function writeIntro($env, $useCache = false, $cacheExisted = false)
     {
+        if ($useCache) {
+            if ($cacheExisted) {
+                $cacheMessage = '(using cache)';
+            } else {
+                $cacheMessage = '(creating cache)';
+            }
+        } else {
+            $cacheMessage = '';
+        }
+
         $this->sections['intro']->overwrite(
-            '<fg=green>Building ' . $env . ' site' .
-            ($useCache ? ' (caching is on)</>' : '</>')
+            '<fg=green>Building '
+            . $env
+            . ' site '
+            . $cacheMessage
+            . '</>'
         );
 
         return $this;

--- a/src/Console/NullProgressBar.php
+++ b/src/Console/NullProgressBar.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TightenCo\Jigsaw\Console;
+
+class NullProgressBar
+{
+    protected $consoleOutput;
+    protected $message;
+
+    public function __construct(ConsoleOutput $consoleOutput, $message = null, $section = null)
+    {
+        $this->consoleOutput = $consoleOutput;
+        $this->message = $message;
+
+        if ($section) {
+            $section->writeln('');
+        }
+    }
+
+    public function getMessage()
+    {
+        return $this->message ? '<comment>' . $this->message . '</comment>' : null;
+    }
+
+    public function start()
+    {
+        return $this;
+    }
+
+    public function addSteps($count)
+    {
+        return $this;
+    }
+
+    public function advance()
+    {
+        return $this;
+    }
+}

--- a/src/Console/ProgressBar.php
+++ b/src/Console/ProgressBar.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace TightenCo\Jigsaw\Console;
+
+use Symfony\Component\Console\Helper\ProgressBar as SymfonyProgressBar;
+use TightenCo\Jigsaw\Console\ConsoleOutput;
+
+class ProgressBar
+{
+    protected $consoleOutput;
+    protected $progressBar;
+    protected $message;
+
+    public function __construct(ConsoleOutput $consoleOutput, $message = null, $section = null)
+    {
+        $this->consoleOutput = $consoleOutput;
+        $this->progressBar = new SymfonyProgressBar($section ?? $consoleOutput);
+        $this->message = $message;
+    }
+
+    public function getMessage()
+    {
+        return $this->message ? '<comment>' . $this->message . '</comment>' : null;
+    }
+
+    public function start()
+    {
+        if ($this->consoleOutput->isVerbose()) {
+            $this->progressBar->setFormat('normal');
+            $this->progressBar->start();
+        }
+
+        return $this;
+    }
+
+    public function addSteps($count)
+    {
+        $this->progressBar->setMaxSteps($this->progressBar->getMaxSteps() + $count);
+
+        return $this;
+    }
+
+    public function advance()
+    {
+        $this->progressBar->advance();
+
+        return $this;
+    }
+}

--- a/src/Console/ProgressBar.php
+++ b/src/Console/ProgressBar.php
@@ -3,7 +3,6 @@
 namespace TightenCo\Jigsaw\Console;
 
 use Symfony\Component\Console\Helper\ProgressBar as SymfonyProgressBar;
-use TightenCo\Jigsaw\Console\ConsoleOutput;
 
 class ProgressBar
 {

--- a/src/Events/FakeDispatcher.php
+++ b/src/Events/FakeDispatcher.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TightenCo\Jigsaw\Events;
+
+ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+
+ class FakeDispatcher implements DispatcherContract
+{
+    public function listen($events, $listener) {}
+
+    public function hasListeners($eventName) {}
+
+    public function subscribe($subscriber) {}
+
+    public function until($event, $payload = []) {}
+
+    public function dispatch($event, $payload = [], $halt = false) {}
+
+    public function push($event, $payload = []) {}
+
+    public function flush($event) {}
+
+    public function forget($event) {}
+
+    public function forgetPushed() {}
+}

--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -4,12 +4,15 @@ namespace TightenCo\Jigsaw\File;
 
 use Illuminate\Filesystem\Filesystem as BaseFilesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class Filesystem extends BaseFilesystem
 {
     public function getFile($directory, $filename)
     {
-        return iterator_to_array(Finder::create()->files()->name($filename)->in($directory), false)[0];
+        $filePath = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $filename;
+
+        return new SplFileInfo($filePath, $directory, $filename);
     }
 
     public function putWithDirectories($file_path, $contents)

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -43,7 +43,12 @@ class InputFile
         return $this->isBladeFile() && in_array($this->getExtension(), $this->extraBladeExtensions) ? $this->getExtension() : '';
     }
 
-    protected function isBladeFile()
+    public function getLastModifiedTime()
+    {
+        return $this->file->getMTime();
+    }
+
+    public function isBladeFile()
     {
         return strpos($this->getBasename(), '.blade.' . $this->getExtension()) > 0;
     }

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -5,20 +5,18 @@ namespace TightenCo\Jigsaw\File;
 class InputFile
 {
     protected $file;
-    protected $basePath;
     protected $extraBladeExtensions = [
         'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
 
-    public function __construct($file, $basePath)
+    public function __construct($file)
     {
         $this->file = $file;
-        $this->basePath = $basePath;
     }
 
     public function topLevelDirectory()
     {
-        $parts = explode(DIRECTORY_SEPARATOR, $this->getRelativeFilePath());
+        $parts = explode(DIRECTORY_SEPARATOR, $this->file->getRelativePathName());
 
         return count($parts) == 1 ? '' : $parts[0];
     }
@@ -43,13 +41,6 @@ class InputFile
     public function getExtraBladeExtension()
     {
         return $this->isBladeFile() && in_array($this->getExtension(), $this->extraBladeExtensions) ? $this->getExtension() : '';
-    }
-
-    public function getRelativeFilePath()
-    {
-        $relative_path = str_replace(resolvePath($this->basePath), '', resolvePath($this->file->getPathname()));
-
-        return trimPath($relative_path);
     }
 
     protected function isBladeFile()

--- a/src/File/TemporaryFilesystem.php
+++ b/src/File/TemporaryFilesystem.php
@@ -4,7 +4,6 @@ namespace TightenCo\Jigsaw\File;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\SplFileInfo;
-use TightenCo\Jigsaw\File\InputFile;
 
 class TemporaryFilesystem
 {

--- a/src/File/TemporaryFilesystem.php
+++ b/src/File/TemporaryFilesystem.php
@@ -43,6 +43,11 @@ class TemporaryFilesystem
         return $path;
     }
 
+    public function hasTempDirectory()
+    {
+        return $this->filesystem->exists($this->tempPath);
+    }
+
     private function delete($path)
     {
         $this->filesystem->delete($path);

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -3,6 +3,7 @@
 namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
+use TightenCo\Jigsaw\File\TemporaryFilesystem;
 use TightenCo\Jigsaw\PageData;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 use TightenCo\Jigsaw\View\ViewRenderer;
@@ -14,7 +15,7 @@ class BladeHandler
     private $view;
     private $hasFrontMatter;
 
-    public function __construct($temporaryFilesystem, FrontMatterParser $parser, ViewRenderer $viewRenderer)
+    public function __construct(TemporaryFilesystem $temporaryFilesystem, FrontMatterParser $parser, ViewRenderer $viewRenderer)
     {
         $this->temporaryFilesystem = $temporaryFilesystem;
         $this->parser = $parser;
@@ -77,12 +78,12 @@ class BladeHandler
 
     private function renderWithFrontMatter($file, $pageData)
     {
-        return $this->temporaryFilesystem->put(
+        $bladeFilePath = $this->temporaryFilesystem->put(
             $this->parser->getBladeContent($file->getContents()),
-            function ($path) use ($pageData) {
-                return $this->render($path, $pageData);
-            },
-        '.blade.php'
+            $file->getPathname(),
+            '.blade.php'
         );
+
+        return $this->render($bladeFilePath, $pageData);
     }
 }

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -21,7 +21,7 @@ class DefaultHandler
 
     public function handle($file, $pageData)
     {
-        return [
+        return collect([
             new CopyFile(
                 $file->getPathName(),
                 $file->getRelativePath(),
@@ -29,6 +29,6 @@ class DefaultHandler
                 $file->getExtension(),
                 $pageData
             ),
-        ];
+        ]);
     }
 }

--- a/src/Handlers/IgnoredHandler.php
+++ b/src/Handlers/IgnoredHandler.php
@@ -11,6 +11,6 @@ class IgnoredHandler
 
     public function handle($file, $data)
     {
-        return [];
+        return collect([]);
     }
 }

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -3,6 +3,7 @@
 namespace TightenCo\Jigsaw\Handlers;
 
 use TightenCo\Jigsaw\File\OutputFile;
+use TightenCo\Jigsaw\File\TemporaryFilesystem;
 use TightenCo\Jigsaw\PageData;
 use TightenCo\Jigsaw\Parsers\FrontMatterParser;
 use TightenCo\Jigsaw\View\ViewRenderer;
@@ -13,7 +14,7 @@ class MarkdownHandler
     private $parser;
     private $view;
 
-    public function __construct($temporaryFilesystem, FrontMatterParser $parser, ViewRenderer $viewRenderer)
+    public function __construct(TemporaryFilesystem $temporaryFilesystem, FrontMatterParser $parser, ViewRenderer $viewRenderer)
     {
         $this->temporaryFilesystem = $temporaryFilesystem;
         $this->parser = $parser;

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -69,7 +69,7 @@ class MarkdownHandler
 
         if ($cached = $this->getValidCachedFile($file, $uniqueFileName)) {
             return $this->view->render($cached->getPathname(), $pageData);
-        } else if ($file->isBladeFile()) {
+        } elseif ($file->isBladeFile()) {
             return $this->renderBladeMarkdownFile($file, $uniqueFileName, $pageData, $extends);
         } else {
             return $this->renderMarkdownFile($file, $uniqueFileName, $pageData, $extends);

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -78,7 +78,8 @@ class MarkdownHandler
 
     private function renderMarkdownFile($file, $uniqueFileName, $pageData, $extends)
     {
-        $html = $this->parser->parseMarkdown($this->getEscapedMarkdownContent($file));
+        $html = $this->parser->parseMarkdownWithoutFrontMatter($this->getEscapedMarkdownContent($file));
+
         $wrapper = $this->view->renderString(
             "@extends('{$extends}')\n" .
             "@section('{$pageData->page->section}'){$html}@endsection"

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -49,10 +49,7 @@ class PaginatedPageHandler
                 $file->getRelativePath(),
                 $file->getFilenameWithoutExtension(),
                 $extension == 'php' ? 'html' : $extension,
-                $this->render(
-                    $this->parser->getBladeContent($file->getContents()),
-                    $pageData
-                ),
+                $this->render($file, $pageData),
                 $pageData,
                 $page->currentPage
             );
@@ -64,10 +61,15 @@ class PaginatedPageHandler
         return $this->parser->getFrontMatter($file->getContents());
     }
 
-    private function render($bladeContent, $pageData)
+    private function render($file, $pageData)
     {
-        return $this->temporaryFilesystem->put($bladeContent, function ($path) use ($pageData) {
-            return $this->view->render($path, $pageData);
-        }, '.blade.php');
+        $bladeContent = $this->parser->getBladeContent($file->getContents());
+        $bladeFilePath = $this->temporaryFilesystem->put(
+            $bladeContent,
+            $file->getPathname(),
+            '.blade.php'
+        );
+
+        return $this->view->render($bladeFilePath, $pageData);
     }
 }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -14,7 +14,6 @@ class Jigsaw
     protected $siteData;
     protected $dataLoader;
     protected $siteBuilder;
-    protected $consoleOutput;
     protected $verbose;
 
     public function __construct($app, $dataLoader, $remoteItemLoader, $siteBuilder)
@@ -23,14 +22,6 @@ class Jigsaw
         $this->dataLoader = $dataLoader;
         $this->remoteItemLoader = $remoteItemLoader;
         $this->siteBuilder = $siteBuilder;
-        $this->consoleOutput = new ConsoleOutput();
-    }
-
-    public function setVerbose($verbose)
-    {
-        $this->consoleOutput->setVerbosity($verbose ? 0 : -1);
-
-        return $this;
     }
 
     public function build($env, $useCache = false)
@@ -48,7 +39,6 @@ class Jigsaw
 
     protected function buildCollections()
     {
-        $this->consoleOutput->writeln('<comment>Loading collections ...</comment>');
         $this->remoteItemLoader->write($this->siteData->collections, $this->getSourcePath());
         $collectionData = $this->dataLoader->loadCollectionData($this->siteData, $this->getSourcePath());
         $this->siteData = $this->siteData->addCollectionData($collectionData);
@@ -59,7 +49,6 @@ class Jigsaw
     protected function buildSite($useCache)
     {
         $this->outputPaths = $this->siteBuilder
-            ->setConsoleOutput($this->consoleOutput)
             ->setUseCache($useCache)
             ->build(
                 $this->getSourcePath(),

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -33,7 +33,7 @@ class Jigsaw
         return $this;
     }
 
-    public function build($env)
+    public function build($env, $useCache = false)
     {
         $this->env = $env;
         $this->siteData = $this->dataLoader->loadSiteData($this->app->config);
@@ -41,7 +41,7 @@ class Jigsaw
         return $this->fireEvent('beforeBuild')
             ->buildCollections()
             ->fireEvent('afterCollections')
-            ->buildSite()
+            ->buildSite($useCache)
             ->fireEvent('afterBuild')
             ->cleanup();
     }
@@ -56,10 +56,11 @@ class Jigsaw
         return $this;
     }
 
-    protected function buildSite()
+    protected function buildSite($useCache)
     {
         $this->outputPaths = $this->siteBuilder
             ->setConsoleOutput($this->consoleOutput)
+            ->setUseCache($useCache)
             ->build(
                 $this->getSourcePath(),
                 $this->getDestinationPath(),

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -2,9 +2,7 @@
 
 namespace TightenCo\Jigsaw;
 
-use Symfony\Component\Console\Output\ConsoleOutput;
 use TightenCo\Jigsaw\File\Filesystem;
-use TightenCo\Jigsaw\File\TemporaryFilesystem;
 
 class Jigsaw
 {

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -54,7 +54,7 @@ class CollectionDataLoader
             ->reject(function ($file) {
                 return starts_with($file->getFilename(), '_');
             })->map(function ($file) {
-                return new InputFile($file, $this->source);
+                return new InputFile($file);
             })->map(function ($inputFile) use ($collection) {
                 return $this->buildCollectionItem($inputFile, $collection);
             });

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -12,18 +12,20 @@ use TightenCo\Jigsaw\PageVariable;
 
 class CollectionDataLoader
 {
-    private $collectionSettings;
     private $filesystem;
-    private $handlers;
-    private $pageSettings;
+    private $consoleOutput;
     private $pathResolver;
+    private $handlers;
     private $source;
+    private $pageSettings;
+    private $collectionSettings;
 
-    public function __construct($filesystem, $pathResolver, $handlers = [])
+    public function __construct($filesystem, $consoleOutput, $pathResolver, $handlers = [])
     {
         $this->filesystem = $filesystem;
         $this->pathResolver = $pathResolver;
         $this->handlers = collect($handlers);
+        $this->consoleOutput = $consoleOutput;
     }
 
     public function load($siteData, $source)
@@ -31,15 +33,18 @@ class CollectionDataLoader
         $this->source = $source;
         $this->pageSettings = $siteData->page;
         $this->collectionSettings = collect($siteData->collections);
+        $this->consoleOutput->startProgressBar('collections');
 
-        return $this->collectionSettings->map(function ($collectionSettings, $collectionName) {
+        $collections = $this->collectionSettings->map(function ($collectionSettings, $collectionName) {
             $collection = Collection::withSettings($collectionSettings, $collectionName);
             $collection->loadItems($this->buildCollection($collection));
 
             return $collection->updateItems($collection->map(function ($item) {
                 return $this->addCollectionItemContent($item);
             }));
-        })->all();
+        });
+
+        return $collections->all();
     }
 
     private function buildCollection($collection)
@@ -53,11 +58,15 @@ class CollectionDataLoader
         return collect($this->filesystem->allFiles($path))
             ->reject(function ($file) {
                 return starts_with($file->getFilename(), '_');
+            })->tap(function ($files) {
+                $this->consoleOutput->progressBar('collections')->addSteps($files->count());
             })->map(function ($file) {
                 return new InputFile($file);
             })->map(function ($inputFile) use ($collection) {
+                $this->consoleOutput->progressBar('collections')->advance();
+
                 return $this->buildCollectionItem($inputFile, $collection);
-            });
+        });
     }
 
     private function buildCollectionItem($file, $collection)

--- a/src/Loaders/CollectionDataLoader.php
+++ b/src/Loaders/CollectionDataLoader.php
@@ -66,7 +66,7 @@ class CollectionDataLoader
                 $this->consoleOutput->progressBar('collections')->advance();
 
                 return $this->buildCollectionItem($inputFile, $collection);
-        });
+            });
     }
 
     private function buildCollectionItem($file, $collection)

--- a/src/Parsers/FrontMatterParser.php
+++ b/src/Parsers/FrontMatterParser.php
@@ -62,15 +62,15 @@ class FrontMatterParser
     }
 
     /**
-     * Adapted from Mni\FrontYAML
+     * Adapted from Mni\FrontYAML.
      */
     public function extractContent($content)
     {
         $regex = '~^('
-            .'---'                                  # $matches[1] start separator
-            ."){1}[\r\n|\n]*(.*?)[\r\n|\n]+("       # $matches[2] front matter
-            .'---'                                  # $matches[3] end separator
-            ."){1}[\r\n|\n]*(.*)$~s";               # $matches[4] document content
+            . '---'                                  // $matches[1] start separator
+            . "){1}[\r\n|\n]*(.*?)[\r\n|\n]+("       // $matches[2] front matter
+            . '---'                                  // $matches[3] end separator
+            . "){1}[\r\n|\n]*(.*)$~s";               // $matches[4] document content
 
         return preg_match($regex, $content, $matches) === 1 ? ltrim($matches[4]) : $content;
     }

--- a/src/Parsers/FrontMatterParser.php
+++ b/src/Parsers/FrontMatterParser.php
@@ -17,7 +17,7 @@ class FrontMatterParser
 
     public function parseMarkdown($content)
     {
-        return $this->parse($content, true);
+        return $this->parse($content, true)->content;
     }
 
     public function parse($content, $parseMarkdown = false)

--- a/src/Parsers/FrontMatterParser.php
+++ b/src/Parsers/FrontMatterParser.php
@@ -20,6 +20,11 @@ class FrontMatterParser
         return $this->parse($content, true)->content;
     }
 
+    public function parseMarkdownWithoutFrontMatter($content)
+    {
+        return $this->parser->parse($this->extractContent($content))->getContent();
+    }
+
     public function parse($content, $parseMarkdown = false)
     {
         $document = $this->parser->parse($content, $parseMarkdown);
@@ -54,6 +59,20 @@ class FrontMatterParser
         preg_match('/@extends\s*\(\s*[\"|\']\s*(.+?)\s*[\"|\']\s*\)/', $content, $matches);
 
         return isset($matches[1]) ? $matches[1] : null;
+    }
+
+    /**
+     * Adapted from Mni\FrontYAML
+     */
+    public function extractContent($content)
+    {
+        $regex = '~^('
+            .'---'                                  # $matches[1] start separator
+            ."){1}[\r\n|\n]*(.*?)[\r\n|\n]+("       # $matches[2] front matter
+            .'---'                                  # $matches[3] end separator
+            ."){1}[\r\n|\n]*(.*)$~s";               # $matches[4] document content
+
+        return preg_match($regex, $content, $matches) === 1 ? ltrim($matches[4]) : $content;
     }
 
     private function addExtendsToBladeContent($extends, $bladeContent)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -36,12 +36,12 @@ class SiteBuilder
         return $this;
     }
 
-    public function build($source, $dest, $siteData)
+    public function build($source, $destination, $siteData)
     {
         $this->prepareDirectory($this->cachePath, ! $this->useCache);
         $generatedFiles = $this->generateFiles($source, $siteData);
-        $this->prepareDirectory($dest);
-        $outputFiles = $this->writeFiles($dest, $generatedFiles);
+        $this->prepareDirectory($destination);
+        $outputFiles = $this->writeFiles($generatedFiles, $destination);
         $this->cleanup();
 
         return $outputFiles;
@@ -99,7 +99,7 @@ class SiteBuilder
         return $files;
     }
 
-    private function writeFiles($destination, $files)
+    private function writeFiles($files, $destination)
     {
         $this->consoleOutput->writeln('<comment>Writing files to destination ...</comment>');
 
@@ -108,20 +108,20 @@ class SiteBuilder
         });
     }
 
+    private function writeFile($file, $destination)
+    {
+        $directory = $this->getOutputDirectory($file);
+        $this->prepareDirectory("{$destination}/{$directory}");
+        $file->putContents("{$destination}/{$this->getOutputPath($file)}");
+
+        return $this->getOutputLink($file);
+    }
+
     private function handle($file, $siteData)
     {
         $meta = $this->getMetaData($file, $siteData->page->baseUrl);
 
         return $this->getHandler($file)->handle($file, PageData::withPageMetaData($siteData, $meta));
-    }
-
-    private function writeFile($file, $dest)
-    {
-        $directory = $this->getOutputDirectory($file);
-        $this->prepareDirectory("{$dest}/{$directory}");
-        $file->putContents("{$dest}/{$this->getOutputPath($file)}");
-
-        return $this->getOutputLink($file);
     }
 
     private function getHandler($file)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -2,7 +2,6 @@
 
 namespace TightenCo\Jigsaw;
 
-use Symfony\Component\Console\Helper\ProgressBar;
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\File\InputFile;
 
@@ -68,8 +67,8 @@ class SiteBuilder
     private function cleanup()
     {
         if (! $this->useCache) {
-        $this->files->deleteDirectory($this->cachePath);
-    }
+            $this->files->deleteDirectory($this->cachePath);
+        }
     }
 
     private function generateFiles($source, $siteData)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -8,10 +8,11 @@ use TightenCo\Jigsaw\File\InputFile;
 
 class SiteBuilder
 {
-    private $files;
     private $cachePath;
-    private $outputPathResolver;
+    private $files;
     private $handlers;
+    private $outputPathResolver;
+    private $useCache;
 
     public function __construct(Filesystem $files, $cachePath, $outputPathResolver, $handlers = [])
     {
@@ -28,9 +29,16 @@ class SiteBuilder
         return $this;
     }
 
+    public function setUseCache($useCache)
+    {
+        $this->useCache = $useCache;
+
+        return $this;
+    }
+
     public function build($source, $dest, $siteData)
     {
-        $this->prepareDirectory($this->cachePath);
+        $this->prepareDirectory($this->cachePath, ! $this->useCache);
         $generatedFiles = $this->generateFiles($source, $siteData);
         $this->prepareDirectory($dest);
         $outputFiles = $this->writeFiles($dest, $generatedFiles);
@@ -64,10 +72,9 @@ class SiteBuilder
 
     private function cleanup()
     {
-        /**
-         * @todo: prevent this from running when using cache
-         */
+        if (! $this->useCache) {
         $this->files->deleteDirectory($this->cachePath);
+    }
     }
 
     private function generateFiles($source, $siteData)

--- a/src/View/BladeMarkdownEngine.php
+++ b/src/View/BladeMarkdownEngine.php
@@ -39,7 +39,7 @@ class BladeMarkdownEngine implements EngineInterface
     protected function evaluateMarkdown($content)
     {
         try {
-            return $this->markdown->parseMarkdown($content)->content;
+            return $this->markdown->parseMarkdown($content);
         } catch (Exception $e) {
             $this->handleViewException($e);
         } catch (Throwable $e) {

--- a/src/View/MarkdownEngine.php
+++ b/src/View/MarkdownEngine.php
@@ -31,7 +31,7 @@ class MarkdownEngine implements EngineInterface
             $file = $this->file->get($path);
 
             if ($file) {
-                return $this->parser->parseMarkdown($file)->content;
+                return $this->parser->parseMarkdown($file);
             }
         } catch (Exception $e) {
             $this->handleViewException($e);

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -2,11 +2,13 @@
 
 namespace TightenCo\Jigsaw\View;
 
+use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
 
 class ViewRenderer
 {
     private $viewFactory;
+    private $bladeCompiler;
     private $extensionEngines = [
         'md' => 'markdown',
         'markdown' => 'markdown',
@@ -19,9 +21,10 @@ class ViewRenderer
         'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
 
-    public function __construct(Factory $viewFactory)
+    public function __construct(Factory $viewFactory, BladeCompiler $bladeCompiler)
     {
         $this->viewFactory = $viewFactory;
+        $this->bladeCompiler = $bladeCompiler;
         $this->finder = $this->viewFactory->getFinder();
         $this->addExtensions();
     }
@@ -34,6 +37,11 @@ class ViewRenderer
     public function render($path, $data)
     {
         return $this->viewFactory->file($path, $data->all())->render();
+    }
+
+    public function renderString($string)
+    {
+        return $this->bladeCompiler->compileString($string);
     }
 
     private function addExtensions()

--- a/stubs/site/.gitignore
+++ b/stubs/site/.gitignore
@@ -1,3 +1,4 @@
 /build_local/
+/cache/
 /node_modules/
 /vendor/

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -245,7 +245,7 @@ class EventsTest extends TestCase
         });
         $files = $this->setupSource([
             '_posts' => [
-                'post_1.md' => 'Content for post #1',
+                'post_1.md' => "---\ntitle: 'Title for post #1'\n---\nContent for post #1",
             ],
         ]);
         $config = collect([
@@ -262,9 +262,7 @@ class EventsTest extends TestCase
             ],
         ]);
         $this->buildSite($files, $config);
-
-        $this->assertEquals('<p>Content for post #1</p>', $result->post_1->getContent());
-        $this->assertEquals('<p>Content for post #2</p>', $result->post_2->getContent());
+        $this->assertEquals('Title for post #1', $result->post_1->title);
         $this->assertEquals('Title for post #2', $result->post_2->title);
     }
 

--- a/tests/SnapshotTestCase.php
+++ b/tests/SnapshotTestCase.php
@@ -17,7 +17,7 @@ class SnapshotTestCase extends BaseTestCase
     {
         parent::setUpBeforeClass();
 
-        echo shell_exec('./jigsaw build testing');
+        echo shell_exec('./jigsaw build testing -q');
     }
 
     public static function tearDownAfterClass()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,6 +63,7 @@ class TestCase extends BaseTestCase
 
     protected function buildSiteData($vfs, $config = [])
     {
+        $this->app->consoleOutput->setup($verbosity = -1);
         $loader = $this->app->make(DataLoader::class);
         $siteData = $loader->loadSiteData($config);
         $collectionData = $loader->loadCollectionData($siteData, $vfs->url() . '/source');
@@ -72,6 +73,7 @@ class TestCase extends BaseTestCase
 
     public function buildSite($vfs, $config = [])
     {
+        $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($config);
         $this->app->buildPath = [
             'source' => $vfs->url() . '/source',
@@ -80,7 +82,6 @@ class TestCase extends BaseTestCase
 
         return $this->app
             ->make(Jigsaw::class)
-            ->setVerbose(false)
             ->build('test');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,9 +78,9 @@ class TestCase extends BaseTestCase
             'destination' => $vfs->url() . '/build',
         ];
 
-        $jigsaw = $this->app->make(Jigsaw::class);
-        $jigsaw->build('test');
-
-        return $jigsaw;
+        return $this->app
+            ->make(Jigsaw::class)
+            ->setVerbose(false)
+            ->build('test');
     }
 }


### PR DESCRIPTION
(Addresses https://github.com/tightenco/jigsaw/issues/191)

This PR implements a variety of optimizations to improve the performance of running `jigsaw build`. These optimizations are of greatest benefit to large Jigsaw sites (> 1,000 pages or so).

Big thanks to @abdumu who suggested a couple of these improvements in https://github.com/tightenco/jigsaw/pull/226:
- replacing use of Symfony Finder w/ `SplFileInfo`
- using a fake when building the view `Factory`, rather than a mock created by Mockery

In addition, `MarkdownHandler` has been optimized to reduce the amount of I/O involved:
- the number of temporary files created for each Markdown page has been reduced from 4 to 1
- temporary filenames are hashed to take advantage of Blade's built-in caching

## Caching

Finally, support for caching has been added. Caching can be turned on by adding the `--cache` or `-c` option to the `jigsaw build` command, or by adding `'cache' => true` to your `config.php` file. Using the cache will add a `cache` directory to your project root, and will attempt to use those files to speed up subsequent builds. 

> Note that the **first** run with `-c` will not _use_ the cache when building the site, but will _create_ the cache files used in subsequent builds. 

> Running `jigsaw build` without the `-c` option will delete the `cache` directory.

## Progress indicators

The console output has also been improved, to include a progress indicators for the collection processing and site building steps. To view the progress bars, add the `-v` option to `jigsaw build`. To silence output entirely, pass the `-q` (or `--quiet`) option.

![jigsaw-cache-output](https://user-images.githubusercontent.com/357312/44727253-99b77e80-aaa7-11e8-8009-ea5bfb57b96a.gif)


## Benchmarks

These improvements are most noticeable on large Jigsaw sites that use Markdown heavily:

| 6,000 files           |             |
|-----------------------|-------------|
| Original              | 1.6 minutes |
| Optimized             | 11 seconds  |
| Optimized, with cache | 7 seconds   |

| 1,000 files           |            |
|-----------------------|------------|
| Original              | 14 seconds |
| Optimized             | 1 second   |
| Optimized, with cache | .6 seconds |

The changes in this PR substantially reduce memory consumption during `build`. For the 6,000-page demo site, memory consumption was reduced from 180 MB (!) to 39 MB; for the 1,000-page site, memory consumption was reduced from 17 MB to 7 MB.