### PR TITLE
Allow merging optional helpers file to config file

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -60,7 +60,7 @@ $container->instance('buildPath', [
 ]);
 
 $container->bind('config', function ($c) {
-    return (new ConfigFile($c['cwd'] . '/config.php'))->config;
+    return (new ConfigFile($c['cwd'] . '/config.php', $c['cwd'] . '/helpers.php'))->config;
 });
 
 $container->bind('outputPathResolver', function ($c) {

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -6,9 +6,12 @@ class ConfigFile
 {
     public $config;
 
-    public function __construct($file_path)
+    public function __construct($config_path, $helpers_path = '')
     {
-        $this->config = file_exists($file_path) ? include $file_path : [];
+        $config = file_exists($config_path) ? include $config_path : [];
+        $helpers = file_exists($helpers_path) ? include $helpers_path : [];
+
+        $this->config = array_merge($config, $helpers);
         $this->convertStringCollectionsToArray();
     }
 


### PR DESCRIPTION
Closes #263

Copied from issue:

> ### Proposal
> 
> I suggest enabling Jigsaw to check if a `helpers.php` file exists in the project root.
> 
> If true, merge the arrays in `config.php` and `helpers.php`.
> 
> If false, nothing breaks (similar to how the `blade.php` file is optional).
> 
> ### Reason
> 
> Jigsaw's flexibility allows us to easily add any helper in the config file.
> 
> This is great, but generally a config file should consist of constant/static values. It would make sense to put helper functions in a separate file.
> 
> Users should have the option to use a separate file, but still be free to put everything in a single file if they prefer it that way.

Additional note:

I decided to add the code in `ConfigFile.php` because *although helpers is a separate file, it is essentially just an extension of the config*.