### PR TITLE
Add confirmation for custom destination paths

### DIFF
--- a/tests/SnapshotTestCase.php
+++ b/tests/SnapshotTestCase.php
@@ -17,7 +17,7 @@ class SnapshotTestCase extends BaseTestCase
     {
         parent::setUpBeforeClass();
 
-        echo shell_exec('./jigsaw build testing');
+        echo shell_exec('./jigsaw build testing --no-warnings');
     }
 
     public static function tearDownAfterClass()


### PR DESCRIPTION
This commit resolves #276 by presenting the user with a confirmation prompt when the build destination is set to a custom path. A `--no-warnings` option can be passed to the command to bypass this check.