### PR TITLE
Remove old pre-1.0 upgrading instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,14 +3,3 @@
 Simple static sites with Laravel's [Blade](https://laravel.com/docs/blade).
 
 For documentation, visit https://jigsaw.tighten.co/docs/installation/
-
----
-
-### Upgrading from an earlier version?
-
-__Version 1.0 includes a change to the way site variables are referenced in your templates.__
-
-Site variables defined in `config.php`, as well as any variables defined in the YAML front matter of a page, are now accessible under the `$page` object, rather than by referencing the variable name itself. Blade templates that include variables will need to be updated so that all variables are prefixed with `$page->`.
-
-Check out https://jigsaw.tighten.co/docs/upgrading/ for an example.
-


### PR DESCRIPTION
Pre-1.0 upgrade page was [removed from tightenco/jigsaw-site](https://github.com/tightenco/jigsaw-site/commit/2942673693aacc7db115c4d17a334357cb728048).

Fixes #295.