### PR TITLE
Fix permalinks paths and collection sorting

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -59,7 +59,7 @@ class Collection extends BaseCollection
         });
 
         if (! $sortSettings->count()) {
-            return $items;
+            $sortSettings = [['key' => 'filename', 'direction' => 1]];
         }
 
         return $items->sort(function ($item_1, $item_2) use ($sortSettings) {
@@ -83,6 +83,6 @@ class Collection extends BaseCollection
 
     private function getValueForSorting($item, $key)
     {
-        return strtolower($item->$key instanceof Closure ? $item->$key($item) : $item->$key);
+        return strtolower($item->$key instanceof Closure ? $item->$key($item) : $item->get($key) ?? $item->_meta->get($key));
     }
 }

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -168,6 +168,6 @@ class SiteBuilder
 
     private function getFilePermalink($file)
     {
-        return $file->data()->page->permalink ? resolvePath(urldecode($file->data()->page->permalink)) : null;
+        return $file->data()->page->permalink ? '/' . resolvePath(urldecode($file->data()->page->permalink)) : null;
     }
 }

--- a/tests/PermalinkTest.php
+++ b/tests/PermalinkTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests;
+
+class PermalinkTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function markdown_file_with_permalink_is_built_at_permalink_destination_when_pretty_urls_is_off()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><p>Permalink file</p></div>',
+            $files->getChild('build/permalink.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function markdown_file_with_permalink_is_built_at_permalink_destination_when_pretty_urls_is_on()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals(
+            '<div><p>Permalink file</p></div>',
+            $files->getChild('build/permalink.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function markdown_file_with_nested_permalink_is_built_at_permalink_destination()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: nested/permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><p>Permalink file</p></div>',
+            $files->getChild('build/nested/permalink.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function markdown_file_with_nested_permalink_is_built_at_permalink_destination_when_pretty_urls_is_on()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: nested/permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals(
+            '<div><p>Permalink file</p></div>',
+            $files->getChild('build/nested/permalink.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function permalink_can_contain_leading_slash()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: /permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals(
+            '<div><p>Permalink file</p></div>',
+            $files->getChild('build/permalink.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function permalink_in_output_paths_contains_leading_slash_if_included_in_permalink()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: /permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $jigsaw = $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals('/permalink.html', $jigsaw->getOutputPaths()[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function permalink_in_output_paths_contains_leading_slash_if_not_included_in_permalink()
+    {
+        $yaml_header = implode("\n", ['---', 'permalink: permalink.html', 'extends: _layouts.master', 'section: content', '---']);
+        $files = $this->setupSource([
+            '_layouts' => ['master.blade.php' => "<div>@yield('content')</div>"],
+            'test.md' => $yaml_header . 'Permalink file',
+        ]);
+        $jigsaw = $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals('/permalink.html', $jigsaw->getOutputPaths()[0]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,12 +2,13 @@
 
 namespace Tests;
 
-use \Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use TightenCo\Jigsaw\File\Filesystem;
 use TightenCo\Jigsaw\File\InputFile;
 use TightenCo\Jigsaw\Jigsaw;
 use TightenCo\Jigsaw\Loaders\DataLoader;
+use TightenCo\Jigsaw\PathResolvers\PrettyOutputPathResolver;
+use \Mockery;
 use org\bovigo\vfs\vfsStream;
 
 class TestCase extends BaseTestCase
@@ -73,7 +74,7 @@ class TestCase extends BaseTestCase
         return $siteData->addCollectionData($collectionData);
     }
 
-    public function buildSite($vfs, $config = [])
+    public function buildSite($vfs, $config = [], $pretty = false)
     {
         $this->app->consoleOutput->setup($verbosity = -1);
         $this->app->config = collect($config);
@@ -81,6 +82,10 @@ class TestCase extends BaseTestCase
             'source' => $vfs->url() . '/source',
             'destination' => $vfs->url() . '/build',
         ];
+
+        if ($pretty) {
+            $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
+        }
 
         return $this->app
             ->make(Jigsaw::class)

--- a/tests/config.php
+++ b/tests/config.php
@@ -6,7 +6,7 @@ return [
         'source' => 'tests/source',
         'destination' => 'tests/build-testing',
     ],
-    'baseUrl' => 'http://jigsaw-test.dev',
+    'baseUrl' => 'http://jigsaw.test',
     'global_array' => [1, 2, 3],
     'global_variable' => 'some global variable',
     'number' => '98765',

--- a/tests/snapshots/2/index.html
+++ b/tests/snapshots/2/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/2</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/2</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,30 +111,30 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/">&lt;</a>
+                            <a href="http://jigsaw.test/">&lt;&lt;</a>
+                <a href="http://jigsaw.test/">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/2" class="pagination__number selected">2</a>
-                            <a href="http://jigsaw-test.dev/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/2" class="pagination__number selected">2</a>
+                            <a href="http://jigsaw.test/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/3">&gt;</a>
-                <a href="http://jigsaw-test.dev/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/3">&gt;</a>
+                <a href="http://jigsaw.test/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/3-third-post">My Third Post</a></h3>
         <p class="text-sm">by Keith Damiani · 03/01/2016 · Number 4</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a></h3>
         <p class="text-sm">by Matt Stauffer · 04/01/2016 · Number 3</p>
         <div class="p-xs-b-6 border-b"><div class="panel p-xs-4 m-xs-y-4">
     <h4>A Blade/Markdown hybrid.</h4>

--- a/tests/snapshots/3/index.html
+++ b/tests/snapshots/3/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/3</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/3</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,23 +111,23 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/2">&lt;</a>
+                            <a href="http://jigsaw.test/">&lt;&lt;</a>
+                <a href="http://jigsaw.test/2">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/3" class="pagination__number selected">3</a>
-                            <a href="http://jigsaw-test.dev/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/3" class="pagination__number selected">3</a>
+                            <a href="http://jigsaw.test/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/4">&gt;</a>
-                <a href="http://jigsaw-test.dev/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/4">&gt;</a>
+                <a href="http://jigsaw.test/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a></h3>
         <p class="text-sm">by Taylor Otwell · 05/01/2016 · Number 2</p>
         <div class="p-xs-b-6 border-b"><p>Normal <strong>Markdown</strong> post. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus earum distinctio, laboriosam dolorem delectus voluptatem odio qui mollitia officia. Impedit nemo aliquid ipsa pariatur recusandae perferendis autem tenetur, porro tempore.</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe, voluptatibus dignissimos expedita quae et sit quia ipsa error blanditiis delectus at consequatur doloremque ratione nesciunt commodi nihil temporibus.</p>
@@ -136,7 +136,7 @@
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a></h3>
         <p class="text-sm">by Default Author · 06/01/2016 · Number 1</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>

--- a/tests/snapshots/4/index.html
+++ b/tests/snapshots/4/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/4</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/4</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,13 +111,13 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/3">&lt;</a>
+                            <a href="http://jigsaw.test/">&lt;&lt;</a>
+                <a href="http://jigsaw.test/3">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/4" class="pagination__number selected">4</a>
+                            <a href="http://jigsaw.test/" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/4" class="pagination__number selected">4</a>
             
                             &gt; &gt;&gt;
                     </div>
@@ -126,7 +126,7 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a></h3>
         <p class="text-sm">by Adam Wathan · 04/12/2017 · Number 7</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>

--- a/tests/snapshots/404-permalink-test.html
+++ b/tests/snapshots/404-permalink-test.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/404</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/404</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/a-regular-page/index.html
+++ b/tests/snapshots/a-regular-page/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/a-regular-page</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/a-regular-page</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/categories/faq/index.html
+++ b/tests/snapshots/categories/faq/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item selected" href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/categories/faq</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/categories/faq</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -104,8 +104,8 @@
         <div class="col-xs-6 text-right">
             <h2>
 
-                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw-test.dev/categories/news">news</a>
-                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw-test.dev/categories/faq">faq</a>
+                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw.test/categories/news">news</a>
+                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw.test/categories/faq">faq</a>
                 
             </h2>
         </div>
@@ -116,14 +116,14 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/3-third-post">My Third Post</a></h3>
         <p class="text-sm">by Keith Damiani · 03/01/2016 · Number 4</p>
         <p class="p-xs-b-6 border-b">...</p>
     </div>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a></h3>
         <p class="text-sm">by Matt Stauffer · 04/01/2016 · Number 3</p>
         <p class="p-xs-b-6 border-b">
     A Blade/Markdown hybrid.
@@ -134,7 +134,7 @@ So you can mix {{ strtouppe...</p>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a></h3>
         <p class="text-sm">by Default Author · 06/01/2016 · Number 1</p>
         <p class="p-xs-b-6 border-b">...</p>
     </div>

--- a/tests/snapshots/categories/news/index.html
+++ b/tests/snapshots/categories/news/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item selected" href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/categories/news</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/categories/news</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -104,8 +104,8 @@
         <div class="col-xs-6 text-right">
             <h2>
 
-                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw-test.dev/categories/news">news</a>
-                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw-test.dev/categories/faq">faq</a>
+                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw.test/categories/news">news</a>
+                                <a class="btn btn-primary-outline btn-sm m-xs-l-2 text-uppercase" href="http://jigsaw.test/categories/faq">faq</a>
                 
             </h2>
         </div>
@@ -116,7 +116,7 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a></h3>
         <p class="text-sm">by Adam Wathan · 01/02/2016 · Number 6</p>
         <p class="p-xs-b-6 border-b">First post! abcdefzzzyyy
 This is a standard Markdown post. Note that section is optional in the frontmatter if using @yield('content') in the parent template.
@@ -125,7 +125,7 @@ If using a different ...</p>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/2-second-post">My Second Post</a></h3>
         <p class="text-sm">by Default Author · 02/01/2016 · Number 5</p>
         <p class="p-xs-b-6 border-b">This post does not have an author specified in the frontmatter, and so uses the default author from the posts/variables array in collections.php
 Markdown formatting test
@@ -134,14 +134,14 @@ Lorem ipsu...</p>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a></h3>
         <p class="text-sm">by Taylor Otwell · 05/01/2016 · Number 2</p>
         <p class="p-xs-b-6 border-b">Normal Markdown post. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus earum distinctio, laboriosam dolorem delectus voluptatem odio qui mollitia officia. Impedi...</p>
     </div>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a></h3>
         <p class="text-sm">by Adam Wathan · 04/12/2017 · Number 7</p>
         <p class="p-xs-b-6 border-b">...</p>
     </div>

--- a/tests/snapshots/collection-tests/index.html
+++ b/tests/snapshots/collection-tests/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/collection-tests</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/collection-tests</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -114,7 +114,7 @@
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/collection-tests/mdown-extension-test">.mdown Extension Test</a></h3>
+            <h3><a href="http://jigsaw.test/collection-tests/mdown-extension-test">.mdown Extension Test</a></h3>
 
             <p class="text-sm">by Markdown · Number 100</p>
 
@@ -131,7 +131,7 @@ https://github.com/tightenco/jigsaw/pull/161...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/collection-tests/simple-one">Test One</a></h3>
+            <h3><a href="http://jigsaw.test/collection-tests/simple-one">Test One</a></h3>
 
             <p class="text-sm">by Adam Wathan · Number 612</p>
 
@@ -148,7 +148,7 @@ If using a different section name (e.g. @yield...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/collection-tests/simple-three">Test Three</a></h3>
+            <h3><a href="http://jigsaw.test/collection-tests/simple-three">Test Three</a></h3>
 
             <p class="text-sm">by Keith Damiani · Number 333</p>
 
@@ -164,7 +164,7 @@ If using a different section name (e.g. @yield...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/collection-tests/simple-two">Test Two</a></h3>
+            <h3><a href="http://jigsaw.test/collection-tests/simple-two">Test Two</a></h3>
 
             <p class="text-sm">by Keith Damiani · Number 7</p>
 

--- a/tests/snapshots/collection-tests/mdown-extension-test/index.html
+++ b/tests/snapshots/collection-tests/mdown-extension-test/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/collection-tests/mdown-extension-test</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/collection-tests/mdown-extension-test</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/collection-tests/simple-one/index.html
+++ b/tests/snapshots/collection-tests/simple-one/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/collection-tests/simple-one</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/collection-tests/simple-one</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/collection-tests/simple-three/index.html
+++ b/tests/snapshots/collection-tests/simple-three/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/collection-tests/simple-three</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/collection-tests/simple-three</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/collection-tests/simple-two/index.html
+++ b/tests/snapshots/collection-tests/simple-two/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/collection-tests/simple-two</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/collection-tests/simple-two</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/escape-test-blade/index.html
+++ b/tests/snapshots/escape-test-blade/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/escape-test-blade</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/escape-test-blade</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/escape-test-hybrid/index.html
+++ b/tests/snapshots/escape-test-hybrid/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/escape-test-hybrid</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/escape-test-hybrid</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/escape-test-markdown/index.html
+++ b/tests/snapshots/escape-test-markdown/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/escape-test-markdown</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/escape-test-markdown</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/extension-url-test.atom
+++ b/tests/snapshots/extension-url-test.atom
@@ -2,4 +2,4 @@ Testing getUrl handler in a file with non-html extension
 
 /extension-url-test.atom should be /extension-url-test.atom
 
-http://jigsaw-test.dev/extension-url-test.atom should end with /extension-url-test.atom
+http://jigsaw.test/extension-url-test.atom should end with /extension-url-test.atom

--- a/tests/snapshots/index.html
+++ b/tests/snapshots/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -113,20 +113,20 @@
         <div class="col-xs-6 text-right">
                             &lt;&lt; &lt;
             
-                            <a href="http://jigsaw-test.dev/" class="pagination__number selected">1</a>
-                            <a href="http://jigsaw-test.dev/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/" class="pagination__number selected">1</a>
+                            <a href="http://jigsaw.test/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/2">&gt;</a>
-                <a href="http://jigsaw-test.dev/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/2">&gt;</a>
+                <a href="http://jigsaw.test/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a></h3>
         <p class="text-sm">by Adam Wathan · 01/02/2016 · Number 6</p>
         <div class="p-xs-b-6 border-b"><p>First post! abcdefzzzyyy</p>
 <p>This is a standard <strong>Markdown</strong> post. Note that <code>section</code> is optional in the frontmatter if using <code>@yield('content')</code> in the parent template.</p>
@@ -136,7 +136,7 @@
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/2-second-post">My Second Post</a></h3>
         <p class="text-sm">by Default Author · 02/01/2016 · Number 5</p>
         <div class="p-xs-b-6 border-b"><p>This post does not have an <code>author</code> specified in the frontmatter, and so uses the <strong>default author</strong> from the <code>posts/variables</code> array in <code>collections.php</code></p>
 <h3>Markdown formatting test</h3>

--- a/tests/snapshots/index_test_blade/index.html
+++ b/tests/snapshots/index_test_blade/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/index_test_blade</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/index_test_blade</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -99,7 +99,7 @@
 <h4>Global Variable: some global variable</h4>
 <h4>Path: /index_test_blade</h4>
 <h4>Local Title: A Regular Markdown Page</h4>
-<h4>URL: <a href="http://jigsaw-test.dev/index_test_blade">http://jigsaw-test.dev/index_test_blade</a></h4>
+<h4>URL: <a href="http://jigsaw.test/index_test_blade">http://jigsaw.test/index_test_blade</a></h4>
 <h4>Helper function: hello global! #1991</h4>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe, voluptatibus dignissimos expedita quae et sit quia ipsa error blanditiis delectus at consequatur doloremque ratione nesciunt commodi nihil temporibus.</p>
 <p>{c:#f00}This is Red Text, demonstrating customizing the Markdown parser in <code>bootstrap.php</code>. {/c}</p>

--- a/tests/snapshots/index_test_two/index.html
+++ b/tests/snapshots/index_test_two/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/index_test_two</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/index_test_two</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/mdown-extension-test/index.html
+++ b/tests/snapshots/mdown-extension-test/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/mdown-extension-test</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/mdown-extension-test</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/pagination/2/index.html
+++ b/tests/snapshots/pagination/2/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item selected" href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/pagination/2</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/pagination/2</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,30 +111,30 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/pagination">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/pagination">&lt;</a>
+                            <a href="http://jigsaw.test/pagination">&lt;&lt;</a>
+                <a href="http://jigsaw.test/pagination">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/pagination" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/pagination/2" class="pagination__number selected">2</a>
-                            <a href="http://jigsaw-test.dev/pagination/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/pagination/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/pagination" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/pagination/2" class="pagination__number selected">2</a>
+                            <a href="http://jigsaw.test/pagination/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/pagination/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/pagination/3">&gt;</a>
-                <a href="http://jigsaw-test.dev/pagination/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/pagination/3">&gt;</a>
+                <a href="http://jigsaw.test/pagination/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/3-third-post">My Third Post</a></h3>
         <p class="text-sm">by Keith Damiani · 03/01/2016 · Number 4</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a></h3>
         <p class="text-sm">by Matt Stauffer · 04/01/2016 · Number 3</p>
         <div class="p-xs-b-6 border-b"><div class="panel p-xs-4 m-xs-y-4">
     <h4>A Blade/Markdown hybrid.</h4>

--- a/tests/snapshots/pagination/3/index.html
+++ b/tests/snapshots/pagination/3/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item selected" href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/pagination/3</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/pagination/3</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,23 +111,23 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/pagination">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/pagination/2">&lt;</a>
+                            <a href="http://jigsaw.test/pagination">&lt;&lt;</a>
+                <a href="http://jigsaw.test/pagination/2">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/pagination" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/pagination/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/pagination/3" class="pagination__number selected">3</a>
-                            <a href="http://jigsaw-test.dev/pagination/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/pagination" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/pagination/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/pagination/3" class="pagination__number selected">3</a>
+                            <a href="http://jigsaw.test/pagination/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/pagination/4">&gt;</a>
-                <a href="http://jigsaw-test.dev/pagination/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/pagination/4">&gt;</a>
+                <a href="http://jigsaw.test/pagination/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a></h3>
         <p class="text-sm">by Taylor Otwell · 05/01/2016 · Number 2</p>
         <div class="p-xs-b-6 border-b"><p>Normal <strong>Markdown</strong> post. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus earum distinctio, laboriosam dolorem delectus voluptatem odio qui mollitia officia. Impedit nemo aliquid ipsa pariatur recusandae perferendis autem tenetur, porro tempore.</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe, voluptatibus dignissimos expedita quae et sit quia ipsa error blanditiis delectus at consequatur doloremque ratione nesciunt commodi nihil temporibus.</p>
@@ -136,7 +136,7 @@
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a></h3>
         <p class="text-sm">by Default Author · 06/01/2016 · Number 1</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>

--- a/tests/snapshots/pagination/4/index.html
+++ b/tests/snapshots/pagination/4/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item selected" href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/pagination/4</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/pagination/4</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,13 +111,13 @@
             </h4>
         </div>
         <div class="col-xs-6 text-right">
-                            <a href="http://jigsaw-test.dev/pagination">&lt;&lt;</a>
-                <a href="http://jigsaw-test.dev/pagination/3">&lt;</a>
+                            <a href="http://jigsaw.test/pagination">&lt;&lt;</a>
+                <a href="http://jigsaw.test/pagination/3">&lt;</a>
             
-                            <a href="http://jigsaw-test.dev/pagination" class="pagination__number ">1</a>
-                            <a href="http://jigsaw-test.dev/pagination/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/pagination/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/pagination/4" class="pagination__number selected">4</a>
+                            <a href="http://jigsaw.test/pagination" class="pagination__number ">1</a>
+                            <a href="http://jigsaw.test/pagination/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/pagination/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/pagination/4" class="pagination__number selected">4</a>
             
                             &gt; &gt;&gt;
                     </div>
@@ -126,7 +126,7 @@
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a></h3>
         <p class="text-sm">by Adam Wathan · 04/12/2017 · Number 7</p>
         <div class="p-xs-b-6 border-b"></div>
     </div>

--- a/tests/snapshots/pagination/index.html
+++ b/tests/snapshots/pagination/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item selected" href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/pagination</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/pagination</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -113,20 +113,20 @@
         <div class="col-xs-6 text-right">
                             &lt;&lt; &lt;
             
-                            <a href="http://jigsaw-test.dev/pagination" class="pagination__number selected">1</a>
-                            <a href="http://jigsaw-test.dev/pagination/2" class="pagination__number ">2</a>
-                            <a href="http://jigsaw-test.dev/pagination/3" class="pagination__number ">3</a>
-                            <a href="http://jigsaw-test.dev/pagination/4" class="pagination__number ">4</a>
+                            <a href="http://jigsaw.test/pagination" class="pagination__number selected">1</a>
+                            <a href="http://jigsaw.test/pagination/2" class="pagination__number ">2</a>
+                            <a href="http://jigsaw.test/pagination/3" class="pagination__number ">3</a>
+                            <a href="http://jigsaw.test/pagination/4" class="pagination__number ">4</a>
             
-                            <a href="http://jigsaw-test.dev/pagination/2">&gt;</a>
-                <a href="http://jigsaw-test.dev/pagination/4">&gt;&gt;</a>
+                            <a href="http://jigsaw.test/pagination/2">&gt;</a>
+                <a href="http://jigsaw.test/pagination/4">&gt;&gt;</a>
                     </div>
     </div>
 </div>
 
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a></h3>
         <p class="text-sm">by Adam Wathan · 01/02/2016 · Number 6</p>
         <div class="p-xs-b-6 border-b"><p>First post! abcdefzzzyyy</p>
 <p>This is a standard <strong>Markdown</strong> post. Note that <code>section</code> is optional in the frontmatter if using <code>@yield('content')</code> in the parent template.</p>
@@ -136,7 +136,7 @@
 </div>
 <div class="row">
     <div class="col-xs-12">
-        <h3><a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a></h3>
+        <h3><a href="http://jigsaw.test/posts/2-second-post">My Second Post</a></h3>
         <p class="text-sm">by Default Author · 02/01/2016 · Number 5</p>
         <div class="p-xs-b-6 border-b"><p>This post does not have an <code>author</code> specified in the frontmatter, and so uses the <strong>default author</strong> from the <code>posts/variables</code> array in <code>collections.php</code></p>
 <h3>Markdown formatting test</h3>

--- a/tests/snapshots/people/index.html
+++ b/tests/snapshots/people/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -111,14 +111,14 @@
             <h3>
                 662
 
-                                    <a href="http://jigsaw-test.dev/people/test/adam-wathan">Adam Wathan</a>
+                                    <a href="http://jigsaw.test/people/test/adam-wathan">Adam Wathan</a>
                             </h3>
 
             <p>Filename (meta): adam-wathan</p>
 
-                        <p>Path (WEB): <a href="http://jigsaw-test.dev/people/web/2016-05-16/adam_wathan">/people/web/2016-05-16/adam_wathan</a></p>
-            <p>Path (API): <a href="http://jigsaw-test.dev/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js">/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js</a></p>
-            <p>Path (Test): <a href="http://jigsaw-test.dev/people/test/adam-wathan">/people/test/adam-wathan</a></p>
+                        <p>Path (WEB): <a href="http://jigsaw.test/people/web/2016-05-16/adam_wathan">/people/web/2016-05-16/adam_wathan</a></p>
+            <p>Path (API): <a href="http://jigsaw.test/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js">/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js</a></p>
+            <p>Path (Test): <a href="http://jigsaw.test/people/test/adam-wathan">/people/test/adam-wathan</a></p>
             
             <p>Role (frontmatter): Developer</p>
             <p>Using global helper function: Adam&#039;s biography:
@@ -128,13 +128,13 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe,
             <h3>
                 1
 
-                                    <a href="http://jigsaw-test.dev/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js">Dan Sheetz</a>
+                                    <a href="http://jigsaw.test/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js">Dan Sheetz</a>
                             </h3>
 
             <p>Filename (meta): dan-sheetz</p>
 
-                        <p>Path (WEB): <a href="http://jigsaw-test.dev/people/web/2016-02-01/dan_sheetz">/people/web/2016-02-01/dan_sheetz</a></p>
-            <p>Path (API): <a href="http://jigsaw-test.dev/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js">/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js</a></p>
+                        <p>Path (WEB): <a href="http://jigsaw.test/people/web/2016-02-01/dan_sheetz">/people/web/2016-02-01/dan_sheetz</a></p>
+            <p>Path (API): <a href="http://jigsaw.test/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js">/people/api.test/Dan Sheetz/2016-02-01/dan-sheetz.js</a></p>
             <p>Path (Test): <a href=""></a></p>
             
             <p>Role (frontmatter): CEO</p>
@@ -159,12 +159,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe,
             <h3>
                 12
 
-                                    <a href="http://jigsaw-test.dev/people/web/2016-03-01/keith_damiani">Keith Damiani</a>
+                                    <a href="http://jigsaw.test/people/web/2016-03-01/keith_damiani">Keith Damiani</a>
                             </h3>
 
             <p>Filename (meta): keith-damiani</p>
 
-                        <p>Path (WEB): <a href="http://jigsaw-test.dev/people/web/2016-03-01/keith_damiani">/people/web/2016-03-01/keith_damiani</a></p>
+                        <p>Path (WEB): <a href="http://jigsaw.test/people/web/2016-03-01/keith_damiani">/people/web/2016-03-01/keith_damiani</a></p>
             <p>Path (API): <a href=""></a></p>
             <p>Path (Test): <a href=""></a></p>
             
@@ -176,12 +176,12 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe,
             <h3>
                 2001
 
-                                    <a href="http://jigsaw-test.dev/people/web/2016-04-01/matt_stauffer">Matt Stauffer</a>
+                                    <a href="http://jigsaw.test/people/web/2016-04-01/matt_stauffer">Matt Stauffer</a>
                             </h3>
 
             <p>Filename (meta): matt-stauffer</p>
 
-                        <p>Path (WEB): <a href="http://jigsaw-test.dev/people/web/2016-04-01/matt_stauffer">/people/web/2016-04-01/matt_stauffer</a></p>
+                        <p>Path (WEB): <a href="http://jigsaw.test/people/web/2016-04-01/matt_stauffer">/people/web/2016-04-01/matt_stauffer</a></p>
             <p>Path (API): <a href=""></a></p>
             <p>Path (Test): <a href=""></a></p>
             
@@ -193,14 +193,14 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat, placeat saepe,
             <h3>
                 662
 
-                                    <a href="http://jigsaw-test.dev/people/test/test-lang">Adam Wathan</a>
+                                    <a href="http://jigsaw.test/people/test/test-lang">Adam Wathan</a>
                             </h3>
 
             <p>Filename (meta): test-lang</p>
 
-                        <p>Path (WEB): <a href="http://jigsaw-test.dev/people/web/2016-05-16/test_lang">/people/web/2016-05-16/test_lang</a></p>
-            <p>Path (API): <a href="http://jigsaw-test.dev/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js">/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js</a></p>
-            <p>Path (Test): <a href="http://jigsaw-test.dev/people/test/test-lang">/people/test/test-lang</a></p>
+                        <p>Path (WEB): <a href="http://jigsaw.test/people/web/2016-05-16/test_lang">/people/web/2016-05-16/test_lang</a></p>
+            <p>Path (API): <a href="http://jigsaw.test/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js">/people/api.test/Adam Wathan/2016-05-16/adam-wathan.js</a></p>
+            <p>Path (Test): <a href="http://jigsaw.test/people/test/test-lang">/people/test/test-lang</a></p>
             
             <p>Role (frontmatter): Developer</p>
             <p>Using global helper function: Language Test

--- a/tests/snapshots/people/test/adam-wathan/index.html
+++ b/tests/snapshots/people/test/adam-wathan/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/test/adam-wathan</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/test/adam-wathan</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/test/test-lang/index.html
+++ b/tests/snapshots/people/test/test-lang/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/test/test-lang</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/test/test-lang</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/web/2016-02-01/dan_sheetz/index.html
+++ b/tests/snapshots/people/web/2016-02-01/dan_sheetz/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/web/2016-02-01/dan_sheetz</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/web/2016-02-01/dan_sheetz</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/web/2016-03-01/keith_damiani/index.html
+++ b/tests/snapshots/people/web/2016-03-01/keith_damiani/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/web/2016-03-01/keith_damiani</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/web/2016-03-01/keith_damiani</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/web/2016-04-01/matt_stauffer/index.html
+++ b/tests/snapshots/people/web/2016-04-01/matt_stauffer/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/web/2016-04-01/matt_stauffer</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/web/2016-04-01/matt_stauffer</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/web/2016-05-16/adam_wathan/index.html
+++ b/tests/snapshots/people/web/2016-05-16/adam_wathan/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/web/2016-05-16/adam_wathan</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/web/2016-05-16/adam_wathan</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/people/web/2016-05-16/test_lang/index.html
+++ b/tests/snapshots/people/web/2016-05-16/test_lang/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item selected" href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/people/web/2016-05-16/test_lang</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/people/web/2016-05-16/test_lang</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/post-demo/index.html
+++ b/tests/snapshots/post-demo/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/post-demo</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/post-demo</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/posts/1-my-first-post/index.html
+++ b/tests/snapshots/posts/1-my-first-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/1-my-first-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/1-my-first-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -129,7 +129,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/2-second-post">
+                                <p><a href="http://jigsaw.test/posts/2-second-post">
                     My Second Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -160,24 +160,24 @@ This is a standard Markdown post. Note that section is optional in the fron ...<
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/news"><em>news</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/news"><em>news</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a>:
+                <a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a>:
                 <em>First post! abcdefzzzyyy
 This is a standard Markdo...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a>:
+                <a href="http://jigsaw.test/posts/2-second-post">My Second Post</a>:
                 <em>This post does not have an author specified in the...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a>:
+                <a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a>:
                 <em>Normal Markdown post. Lorem ipsum dolor sit amet, ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a>:
+                <a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/2-second-post/index.html
+++ b/tests/snapshots/posts/2-second-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/2-second-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/2-second-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -124,7 +124,7 @@
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/1-my-first-post">
+                                <p><a href="http://jigsaw.test/posts/1-my-first-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My First Post
                 </a></p>
@@ -133,7 +133,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/3-third-post">
+                                <p><a href="http://jigsaw.test/posts/3-third-post">
                     My Third Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -168,24 +168,24 @@
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/news"><em>news</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/news"><em>news</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a>:
+                <a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a>:
                 <em>First post! abcdefzzzyyy
 This is a standard Markdo...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a>:
+                <a href="http://jigsaw.test/posts/2-second-post">My Second Post</a>:
                 <em>This post does not have an author specified in the...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a>:
+                <a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a>:
                 <em>Normal Markdown post. Lorem ipsum dolor sit amet, ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a>:
+                <a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/3-third-post/index.html
+++ b/tests/snapshots/posts/3-third-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/3-third-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/3-third-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -124,7 +124,7 @@
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/2-second-post">
+                                <p><a href="http://jigsaw.test/posts/2-second-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My Second Post
                 </a></p>
@@ -133,7 +133,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/4-fourth-post">
+                                <p><a href="http://jigsaw.test/posts/4-fourth-post">
                     My Fourth Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -172,22 +172,22 @@ This filename ends with blade.md and is processed by both the Blade p...</em></p
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/faq"><em>faq</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/faq"><em>faq</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a>:
+                <a href="http://jigsaw.test/posts/3-third-post">My Third Post</a>:
                 <em>...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a>:
+                <a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a>:
                 <em>
     A Blade/Markdown hybrid.
 
 This filename ends ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a>:
+                <a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/4-fourth-post/index.html
+++ b/tests/snapshots/posts/4-fourth-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/4-fourth-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/4-fourth-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -124,7 +124,7 @@
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/3-third-post">
+                                <p><a href="http://jigsaw.test/posts/3-third-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My Third Post
                 </a></p>
@@ -133,7 +133,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/5-fifth-post">
+                                <p><a href="http://jigsaw.test/posts/5-fifth-post">
                     My Fifth Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -185,22 +185,22 @@ This filename ends with blade.md and is processed by both the Blade p ...</em></
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/faq"><em>faq</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/faq"><em>faq</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a>:
+                <a href="http://jigsaw.test/posts/3-third-post">My Third Post</a>:
                 <em>...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a>:
+                <a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a>:
                 <em>
     A Blade/Markdown hybrid.
 
 This filename ends ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a>:
+                <a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/5-fifth-post/index.html
+++ b/tests/snapshots/posts/5-fifth-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/5-fifth-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/5-fifth-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -124,7 +124,7 @@
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/4-fourth-post">
+                                <p><a href="http://jigsaw.test/posts/4-fourth-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My Fourth Post
                 </a></p>
@@ -133,7 +133,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/6-sixth-post">
+                                <p><a href="http://jigsaw.test/posts/6-sixth-post">
                     My Sixth Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -162,24 +162,24 @@
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/news"><em>news</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/news"><em>news</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a>:
+                <a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a>:
                 <em>First post! abcdefzzzyyy
 This is a standard Markdo...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a>:
+                <a href="http://jigsaw.test/posts/2-second-post">My Second Post</a>:
                 <em>This post does not have an author specified in the...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a>:
+                <a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a>:
                 <em>Normal Markdown post. Lorem ipsum dolor sit amet, ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a>:
+                <a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/6-sixth-post/index.html
+++ b/tests/snapshots/posts/6-sixth-post/index.html
@@ -13,7 +13,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -21,7 +21,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -34,31 +34,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -85,12 +85,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/6-sixth-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/6-sixth-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -124,7 +124,7 @@
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/5-fifth-post">
+                                <p><a href="http://jigsaw.test/posts/5-fifth-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My Fifth Post
                 </a></p>
@@ -133,7 +133,7 @@
 
             <div class="col-xs-6 text-right">
 
-                                <p><a href="http://jigsaw-test.dev/posts/7-blade-post">
+                                <p><a href="http://jigsaw.test/posts/7-blade-post">
                     My Blade Post
                     <icon class="chevron_right m-xs-l-2"></icon>
                 </a></p>
@@ -177,22 +177,22 @@
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/faq"><em>faq</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/faq"><em>faq</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a>:
+                <a href="http://jigsaw.test/posts/3-third-post">My Third Post</a>:
                 <em>...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a>:
+                <a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a>:
                 <em>
     A Blade/Markdown hybrid.
 
 This filename ends ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a>:
+                <a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/7-blade-post/index.html
+++ b/tests/snapshots/posts/7-blade-post/index.html
@@ -15,7 +15,7 @@ This is a standard Blade text page as part of a collection
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -23,7 +23,7 @@ This is a standard Blade text page as part of a collection
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -36,31 +36,31 @@ This is a standard Blade text page as part of a collection
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -87,12 +87,12 @@ This is a standard Blade text page as part of a collection
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts/7-blade-post</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts/7-blade-post</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -126,7 +126,7 @@ This is a standard Blade text page as part of a collection
         <div class="row">
             <div class="col-xs-6 text-left">
 
-                                <p><a href="http://jigsaw-test.dev/posts/6-sixth-post">
+                                <p><a href="http://jigsaw.test/posts/6-sixth-post">
                     <icon class="chevron_left m-xs-r-2"></icon>
                     My Sixth Post
                 </a></p>
@@ -151,24 +151,24 @@ This is a standard Blade text page as part of a collection
     <div class="border-b p-xs-y-6">
         <p class="text-xs text-dark-soft">Access a Jigsaw Collection as Illuminate Collection</p>
 
-        <h4>Related <a href="http://jigsaw-test.dev/categories/news"><em>news</em></a> posts:</h4>
+        <h4>Related <a href="http://jigsaw.test/categories/news"><em>news</em></a> posts:</h4>
 
         <div class="row">
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a>:
+                <a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a>:
                 <em>First post! abcdefzzzyyy
 This is a standard Markdo...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a>:
+                <a href="http://jigsaw.test/posts/2-second-post">My Second Post</a>:
                 <em>This post does not have an author specified in the...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a>:
+                <a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a>:
                 <em>Normal Markdown post. Lorem ipsum dolor sit amet, ...</em>
             </div>
                         <div class="col-xs-9 col-xs-offset-3 p-xs-y-2 border-b">
-                <a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a>:
+                <a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a>:
                 <em>...</em>
             </div>
                     </div>

--- a/tests/snapshots/posts/index.html
+++ b/tests/snapshots/posts/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item selected" href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/posts</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/posts</p>
         </div>
 
         <div class="p-xs-t-4">
@@ -103,7 +103,7 @@
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/1-my-first-post">My First Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/1-my-first-post">My First Post</a></h3>
 
             <p class="text-sm">by Adam Wathan · 01/02/2016 · Number 6</p>
 
@@ -118,7 +118,7 @@ If using a different ...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/2-second-post">My Second Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/2-second-post">My Second Post</a></h3>
 
             <p class="text-sm">by Default Author · 02/01/2016 · Number 5</p>
 
@@ -133,7 +133,7 @@ Lorem ipsu...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/3-third-post">My Third Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/3-third-post">My Third Post</a></h3>
 
             <p class="text-sm">by Keith Damiani · 03/01/2016 · Number 4</p>
 
@@ -146,7 +146,7 @@ Lorem ipsu...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/4-fourth-post">My Fourth Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/4-fourth-post">My Fourth Post</a></h3>
 
             <p class="text-sm">by Matt Stauffer · 04/01/2016 · Number 3</p>
 
@@ -163,7 +163,7 @@ So you can mix {{ strtouppe...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/5-fifth-post">My Fifth Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/5-fifth-post">My Fifth Post</a></h3>
 
             <p class="text-sm">by Taylor Otwell · 05/01/2016 · Number 2</p>
 
@@ -176,7 +176,7 @@ So you can mix {{ strtouppe...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/6-sixth-post">My Sixth Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/6-sixth-post">My Sixth Post</a></h3>
 
             <p class="text-sm">by Default Author · 06/01/2016 · Number 1</p>
 
@@ -189,7 +189,7 @@ So you can mix {{ strtouppe...</p>
 
     <div class="row">
         <div class="col-xs-12">
-            <h3><a href="http://jigsaw-test.dev/posts/7-blade-post">My Blade Post</a></h3>
+            <h3><a href="http://jigsaw.test/posts/7-blade-post">My Blade Post</a></h3>
 
             <p class="text-sm">by Adam Wathan · 04/12/2017 · Number 7</p>
 

--- a/tests/snapshots/remove-invalid-characters-from-paths/index.html
+++ b/tests/snapshots/remove-invalid-characters-from-paths/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/remove-invalid-characters-from-paths</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/remove-invalid-characters-from-paths</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/sort-test-multi/index.html
+++ b/tests/snapshots/sort-test-multi/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item " href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/sort-test-multi</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/sort-test-multi</p>
         </div>
 
         <div class="p-xs-t-4">

--- a/tests/snapshots/variables/index.html
+++ b/tests/snapshots/variables/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <link rel="stylesheet" href="http://jigsaw-test.dev/css/main.css">
+        <link rel="stylesheet" href="http://jigsaw.test/css/main.css">
     </head>
     <body class="border-t-3 border-primary full-height">
 
@@ -12,7 +12,7 @@
             <div class="container">
                 <div class="navbar-content">
                     <div>
-                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw-test.dev">
+                        <a class="link-plain text-xxl flex-y-center" href="http://jigsaw.test">
                             <strong>Jigsaw Collections Demo</strong>
                         </a>
                     </div>
@@ -25,31 +25,31 @@
 
                 <div class="col-xs-4">
                     <nav class="nav-list">
-    <a class="nav-list-item " href="http://jigsaw-test.dev/posts">
+    <a class="nav-list-item " href="http://jigsaw.test/posts">
         <icon></icon>Posts
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/pagination">
+    <a class="nav-list-item " href="http://jigsaw.test/pagination">
         <icon></icon>Pagination
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/categories/news">
+    <a class="nav-list-item " href="http://jigsaw.test/categories/news">
         <icon></icon>Categories
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/people">
+    <a class="nav-list-item " href="http://jigsaw.test/people">
         <icon></icon>People
     </a>
 
-    <a class="nav-list-item selected" href="http://jigsaw-test.dev/variables">
+    <a class="nav-list-item selected" href="http://jigsaw.test/variables">
         <icon></icon>Variables
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/json-test.json">
+    <a class="nav-list-item " href="http://jigsaw.test/json-test.json">
         <icon></icon>JSON
     </a>
 
-    <a class="nav-list-item " href="http://jigsaw-test.dev/text-test.txt">
+    <a class="nav-list-item " href="http://jigsaw.test/text-test.txt">
         <icon></icon>Text
     </a>
 </nav>
@@ -76,12 +76,12 @@
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">BASE URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test</p>
         </div>
 
         <div class="p-xs-y-4 border-b">
             <p class="text-xs text-dark-soft text-uppercase">URL:</p>
-            <p class="p-xs-l-2 text-sm">http://jigsaw-test.dev/variables</p>
+            <p class="p-xs-l-2 text-sm">http://jigsaw.test/variables</p>
         </div>
 
         <div class="p-xs-t-4">


### PR DESCRIPTION
This PR includes two fixes:
- prepends `/` to permalinks, to match the handling of normal file paths when calling `getOutputPaths()` (which is used when generating sitemaps, for example)
- fixes a regression in default collection item sorting that was introduced when switching away from using Symfony's `Finder` component for file retrieval