### PR TITLE
rightTrim Directory Path

### DIFF
--- a/src/File/Filesystem.php
+++ b/src/File/Filesystem.php
@@ -19,7 +19,7 @@ class Filesystem extends BaseFilesystem
     {
         $directory_path = collect(explode('/', $file_path));
         $directory_path->pop();
-        $directory_path = trimPath($directory_path->implode('/'));
+        $directory_path = rightTrimPath($directory_path->implode('/'));
 
         if (! $this->isDirectory($directory_path)) {
             $this->makeDirectory($directory_path, 0755, true);

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -522,6 +522,17 @@ class EventsTest extends TestCase
 
         $this->assertEquals('test', $source->getChild('build/new_directory/file.html')->getContent());
     }
+
+    /** @test */
+    public function user_can_write_a_new_output_file_in_a_new_directory_in_after_build_event_listener_when_path_begins_with_slash()
+    {
+        $this->app['events']->afterBuild(function ($jigsaw) use (&$result) {
+            $result = $jigsaw->writeOutputFile('/new_directory/file.html', 'test');
+        });
+        $this->buildSite($source = $this->setupSource());
+
+        $this->assertEquals('test', $source->getChild('build/new_directory/file.html')->getContent());
+    }
 }
 
 class TestListener


### PR DESCRIPTION
Fixes #322.

The test would still work if `trimPath()` is used.
I just tried to test if `writeOutputFile` can handle a leading slash in `$file_path`.