### PR TITLE
Allow international characters in collection file names

### DIFF
--- a/src/PathResolvers/CollectionPathResolver.php
+++ b/src/PathResolvers/CollectionPathResolver.php
@@ -174,7 +174,7 @@ class CollectionPathResolver
             $value = str_replace($val, $key, $value);
         }
 
-        return preg_replace('/[^\x20-\x7E]/u', '', $value);
+        return preg_replace('/[\x{00a1}-\x{00bf}|\x{2120}\x{2122}]/u', '', $value);
     }
 
     /**

--- a/tests/FilePathTest.php
+++ b/tests/FilePathTest.php
@@ -69,6 +69,36 @@ class FilePathTest extends TestCase
         $this->assertEquals('/has_invalid_characters', $outputPath[0]);
     }
 
+    public function test_international_characters_in_filename_are_allowed_when_using_default_path_config()
+    {
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
+        $pathResolver = $this->app->make(CollectionPathResolver::class);
+        $pageVariable = $this->getPageVariableDummy('테스트-파일-이름');
+        $outputPath = $pathResolver->link(null, $pageVariable);
+
+        $this->assertEquals('/테스트-파일-이름', $outputPath[0]);
+    }
+
+    public function test_international_characters_in_filename_are_allowed_when_using_shorthand_path_config()
+    {
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
+        $pathResolver = $this->app->make(CollectionPathResolver::class);
+        $pageVariable = $this->getPageVariableDummy('테스트-파일-이름');
+        $outputPath = $pathResolver->link('{filename}', $pageVariable);
+
+        $this->assertEquals('/테스트-파일-이름', $outputPath[0]);
+    }
+
+    public function test_international_characters_in_filename_are_allowed_when_using_slugified_shorthand_path_config()
+    {
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
+        $pathResolver = $this->app->make(CollectionPathResolver::class);
+        $pageVariable = $this->getPageVariableDummy('테스트-파일-이름');
+        $outputPath = $pathResolver->link('{_filename}', $pageVariable);
+
+        $this->assertEquals('/테스트_파일_이름', $outputPath[0]);
+    }
+
     protected function getPageVariableDummy($filename)
     {
         return new PageVariable([


### PR DESCRIPTION
This PR addresses https://github.com/tightenco/jigsaw/issues/344. 

Collection item filenames are first transliterated, and then sanitized to remove invalid characters; the second step maintained only letters from the Latin character set, which removed non-Latin (e.g. Korean) characters. Instead, the sanitization will now target common invalid characters explicitly for removal, and leave everything else.

