### PR TITLE
Build dotfiles

### DIFF
--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -73,7 +73,7 @@ class SiteBuilder
 
     private function generateFiles($source, $siteData)
     {
-        $files = collect($this->files->allFiles($source));
+        $files = collect($this->files->files($source));
         $this->consoleOutput->startProgressBar('build', $files->count());
 
         $files = $files->map(function ($file) {

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -15,6 +15,23 @@ class SnapshotTest extends SnapshotTestCase
     /**
      * @test
      */
+    public function dot_files_are_built()
+    {
+        $this->assertFileExists('tests/build-testing/.dotfile-test', 'dotfile was not built');
+    }
+
+    /**
+     * @test
+     */
+    public function ds_store_files_are_not_built()
+    {
+        $this->assertFileNotExists('tests/build-testing/.DS_Store', 'DS_Store was built');
+    }
+
+
+    /**
+     * @test
+     */
     public function all_built_files_contain_expected_content()
     {
         collect($this->build_files)->each(function ($file) {

--- a/tests/SnapshotTestCase.php
+++ b/tests/SnapshotTestCase.php
@@ -32,13 +32,13 @@ class SnapshotTestCase extends BaseTestCase
     {
         try {
             $this->filesystem = new Filesystem();
-            $this->build_files = $this->filesystem->allFiles('tests/build-testing');
+            $this->build_files = $this->filesystem->files('tests/build-testing');
         } catch (\Exception $e) {
             die("Error: Jigsaw test site was not built.\r\n");
         }
 
         try {
-            $this->snapshot_files = $this->filesystem->allFiles('tests/snapshots');
+            $this->snapshot_files = $this->filesystem->files('tests/snapshots');
         } catch (\Exception $e) {
             die("Error: Snapshot files are missing.\r\n");
         }


### PR DESCRIPTION
The SiteBulider and tests use:
Illuminate\Filesystem\Filesystem allFiles()
instead of:
TightenCo\Jigsaw\File\Filesystem files()

As the second param ($hidden = false) isn't set to true, dotfiles are not built.

Added a .DS_Store into the test source

Added two explicit tests
* check that dotfile is present
* check that .DS_Store file isn't present