### PR TITLE
Support filtering collections

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -22,9 +22,12 @@ class Collection extends BaseCollection
 
     public function loadItems($items)
     {
-        $sortedItems = $this->defaultSort($items)->keyBy(function ($item) {
-            return $item->getFilename();
-        });
+        $sortedItems = $this
+            ->defaultSort($items)
+            ->filter($this->getFilter())
+            ->keyBy(function ($item) {
+                return $item->getFilename();
+            });
 
         return $this->updateItems($this->addAdjacentItems($sortedItems));
     }
@@ -48,6 +51,19 @@ class Collection extends BaseCollection
         return $items->each(function ($item) use ($previousItems, $nextItems) {
             $item->_meta->put('previousItem', $previousItems->shift())->put('nextItem', $nextItems->shift());
         });
+    }
+
+    private function getFilter()
+    {
+        $filter = Arr::get($this->settings, 'filter');
+
+        if ($filter) {
+            return $filter;
+        }
+
+        return function ($item) {
+            return true;
+        };
     }
 
     private function defaultSort($items)

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -47,6 +47,10 @@ class CollectionItemHandler
         });
         $pageData->setPageVariableToCollectionItem($this->getCollectionName($file), $file->getFilenameWithoutExtension());
 
+        if ($pageData->page === null) {
+            return null;
+        }
+
         return $handler->handleCollectionItem($file, $pageData)
             ->map(function ($outputFile, $templateToExtend) {
                 if ($templateToExtend) {


### PR DESCRIPTION
This PR creates the base functionality to allow filtering collections. Filtering allows for specific features, like not publishing draft messages, to be implemented by other projects.

Related to #221 