### PR TITLE
run build as part of the serve command

### DIFF
--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -4,6 +4,7 @@ namespace TightenCo\Jigsaw\Console;
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -40,6 +41,12 @@ class ServeCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'What port should we use?',
                 8000
+            )
+            ->addOption(
+                'no-build',
+                null,
+                InputOption::VALUE_NONE,
+                'Skip build before serving?'
             );
     }
 
@@ -48,6 +55,13 @@ class ServeCommand extends Command
         $env = $this->input->getArgument('environment');
         $host = $this->input->getOption('host');
         $port = $this->input->getOption('port');
+
+        if (! $this->input->getOption('no-build')) {
+            $buildCmd = $this->getApplication()->find('build');
+            $buildArgs = new ArrayInput(['env' => $env]);
+
+            $buildCmd->run($buildArgs, $this->output);
+        }
 
         $this->console->info("Server started on http://{$host}:{$port}");
 

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -59,7 +59,6 @@ class ServeCommand extends Command
         if (! $this->input->getOption('no-build')) {
             $buildCmd = $this->getApplication()->find('build');
             $buildArgs = new ArrayInput(['env' => $env]);
-
             $buildCmd->run($buildArgs, $this->output);
         }
 


### PR DESCRIPTION
As someone new to Jigsaw, it was a little weird to me that I had to first run `build` before I could run server. Most static site generators I've ran across run `build` as part of server. This merge request calls `build` by default when doing `serve` (passing in the environment). I've also included a `--no-build` option in `serve`.