### PR TITLE
Update CollectionRemoteItem class to process files as blade.md

### DIFF
--- a/src/Collection/CollectionRemoteItem.php
+++ b/src/Collection/CollectionRemoteItem.php
@@ -27,7 +27,7 @@ class CollectionRemoteItem
 
     public function getFilename()
     {
-        return Arr::get($this->item, 'filename', $this->prefix . ($this->index + 1)) . '.md';
+        return Arr::get($this->item, 'filename', $this->prefix . ($this->index + 1)) . '.blade.md';
     }
 
     protected function getHeader()

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -520,4 +520,30 @@ class RemoteCollectionsTest extends TestCase
             $files->getChild('build/test/test-1.html')->getContent()
         );
     }
+
+    /**
+     * @test
+     */
+    public function blade_directives_in_remote_content_get_parsed()
+    {
+        $config = collect([
+            'collections' => [
+                'collection' => [],
+            ],
+        ]);
+
+        $files = $this->setupSource([
+            '_collection' => [
+                'file_1.blade.md' => 'Test blade file #1',
+                'file_2.blade.md' => 'Test blade file #2',
+            ],
+        ]);
+      
+ 
+        $siteData = $this->buildSiteData($files, $config);
+
+        $this->assertCount(2, $siteData->collection);
+        $this->assertEquals('<p>Test blade file #1</p>', $siteData->collection->file_1->getContent());
+        $this->assertEquals('<p>Test blade file #2</p>', $siteData->collection->file_2->getContent());
+    }
 }

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -528,22 +528,22 @@ class RemoteCollectionsTest extends TestCase
     {
         $config = collect([
             'collections' => [
-                'collection' => [],
+                'test' => [
+                    'extends' => '_layouts.master',
+                    'items' => ["Hey {{ 'there' }}"],
+                ],
             ],
         ]);
-
         $files = $this->setupSource([
-            '_collection' => [
-                'file_1.blade.md' => 'Test blade file #1',
-                'file_2.blade.md' => 'Test blade file #2',
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
             ],
         ]);
-      
- 
-        $siteData = $this->buildSiteData($files, $config);
+        $this->buildSite($files, $config);
 
-        $this->assertCount(2, $siteData->collection);
-        $this->assertEquals('<p>Test blade file #1</p>', $siteData->collection->file_1->getContent());
-        $this->assertEquals('<p>Test blade file #2</p>', $siteData->collection->file_2->getContent());
+        $this->assertEquals(
+            '<div><p>Hey there</p></div>',
+            $files->getChild('build/test/test-1.html')->getContent()
+        );
     }
 }


### PR DESCRIPTION
This PR updates the CollectionRemoteItem class to process remote collection items as `.blade.md` instead of `.md`. 
Closes issue #362 
