### PR TITLE
Correctly print to console for serve command

### DIFF
--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -48,7 +48,7 @@ class ServeCommand extends Command
         $host = $this->input->getOption('host');
         $port = $this->input->getOption('port');
 
-        $this->console->info("Server started on http://localhost:{$port}");
+        $this->console->info("Server started on http://{$host}:{$port}");
 
         passthru("php -S {$host}:{$port} -t " . escapeshellarg($this->getBuildPath($env)));
     }


### PR DESCRIPTION
This PR fixes a regression in the output printed to console when running the `serve` command with a non-default host. The command passed to PHP to serve does honor the `host` parameter correctly so this is just fix for the console output.

Current behavior:
```bash
$ ./vendor/bin/jigsaw serve --host 0.0.0.0
Server started on http://localhost:8000
```

Expected behavior:
```bash
$ ./vendor/bin/jigsaw serve --host 0.0.0.0
Server started on http://0.0.0.0:8000
```

It looks like this was a regression introduced when #266 was merged because the initial implementation of the `host` option (#230) had this code.