### PR TITLE
Temporarily implement PHP 7.4 fix for Parsedown Extra

### DIFF
--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -115,9 +115,8 @@ class JigsawMarkdownParser extends ParsedownExtra
     }
 
     /** 
-     * @todo remove method after the following PR has been merged
-     * https://github.com/erusev/parsedown-extra/pull/135 gets merged
-     * This will resolve the issue where Jigsaw will not work with PHP 7.4
+     * @todo remove after the following PR has been merged
+     * https://github.com/erusev/parsedown-extra/pull/135
      */
     protected function blockHeader($Line)
     {
@@ -136,9 +135,8 @@ class JigsawMarkdownParser extends ParsedownExtra
     }
 
     /** 
-     * @todo remove method after the following PR has been merged
-     * https://github.com/erusev/parsedown-extra/pull/135 gets merged
-     * This will resolve the issue where Jigsaw will not work with PHP 7.4
+     * @todo remove after the following PR has been merged
+     * https://github.com/erusev/parsedown-extra/pull/135
      */
     protected function blockSetextHeader($Line, array $Block = null)
     {
@@ -157,9 +155,8 @@ class JigsawMarkdownParser extends ParsedownExtra
     }
 
     /** 
-     * @todo remove method after the following PR has been merged
-     * https://github.com/erusev/parsedown-extra/pull/135 gets merged
-     * This will resolve the issue where Jigsaw will not work with PHP 7.4
+     * @todo remove after the following PR has been merged
+     * https://github.com/erusev/parsedown-extra/pull/135
      */
     protected function inlineLink($Excerpt)
     {

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -4,8 +4,8 @@ namespace TightenCo\Jigsaw\Parsers;
 
 use DOMDocument;
 use DOMElement;
-use ParsedownExtra;
 use Parsedown;
+use ParsedownExtra;
 
 class JigsawMarkdownParser extends ParsedownExtra
 {


### PR DESCRIPTION
ParsedownExtra has a PR to fix the issue where it errors out in PHP 7.4.

This fix extends the JigsawMarkdown class to utilize the code in the PR at https://github.com/erusev/parsedown-extra/pull/135.

Once that PR is merged in, we can revert this commit.