### PR TITLE
WIP: Merging environment configs deeply or recursively

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -74,11 +74,9 @@ class BuildCommand extends Command
         $environmentConfigPath = $this->getAbsolutePath("config.{$env}.php");
         $environmentConfig = (new ConfigFile($environmentConfigPath))->config;
 
-        $this->app->config = collect($this->app->config)
-            ->merge(collect($environmentConfig))
-            ->filter(function ($item) {
-                return $item !== null;
-            });
+        $this->app->config = collect(
+            ConfigFile::mergeConfigs($this->app->config, $environmentConfig)
+        );
     }
 
     private function updateBuildPaths($env)

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -13,18 +13,33 @@ class ConfigFile
         $config = file_exists($config_path) ? include $config_path : [];
         $helpers = file_exists($helpers_path) ? include $helpers_path : [];
 
-        $this->config = array_merge($config, $helpers);
-        $this->convertStringCollectionsToArray();
+        $this->config = $this->convertStringCollectionsToArray(
+            array_merge($config, $helpers)
+        );
     }
 
-    protected function convertStringCollectionsToArray()
+    protected function convertStringCollectionsToArray($config)
     {
-        $collections = Arr::get($this->config, 'collections');
+        $collections = Arr::get($config, 'collections');
 
         if ($collections) {
-            $this->config['collections'] = collect($collections)->flatMap(function ($value, $key) {
+            $config['collections'] = collect($collections)->flatMap(function ($value, $key) {
                 return is_array($value) ? [$key => $value] : [$value => []];
             });
         }
+
+        return $config;
+    }
+
+    public static function mergeConfigs($baseConfig, $configToMerge)
+    {
+        return (new static(''))->convertStringCollectionsToArray(
+            array_filter(
+                array_replace_recursive(
+                    collect($baseConfig)->toArray(),
+                    collect($configToMerge)->toArray()
+                )
+            )
+        );
     }
 }

--- a/tests/ConfigVariableTest.php
+++ b/tests/ConfigVariableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Arr;
 use TightenCo\Jigsaw\File\ConfigFile;
 
 class ConfigVariableTest extends TestCase
@@ -51,6 +52,51 @@ class ConfigVariableTest extends TestCase
         $this->assertEquals(
             '<div>local</div>',
             $files->getChild('build/variable-test.html')->getContent()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function config_variables_are_merged_recursively()
+    {
+        $config = (new ConfigFile($this->app['cwd'] . '/tests/config.php'))
+            ->config;
+        $configToMerge = [
+            'collections' => [
+                'posts' => [
+                    'sort' => 'date',
+                    'isSelected' => 'foobar'
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            'Default Author',
+            Arr::get($config, 'collections.posts.author')
+        );
+        $this->assertNotEquals(
+            'foobar',
+            Arr::get($config, 'collections.posts.isSelected')
+        );
+        $this->assertNull(Arr::get($config, 'collections.posts.sort'));
+
+        $config = ConfigFile::mergeConfigs($config, $configToMerge);
+
+        $this->assertEquals(
+            'Default Author',
+            Arr::get($config, 'collections.posts.author'),
+            'collections.posts.author was merged but should NOT have been'
+        );
+        $this->assertEquals(
+            'foobar',
+            Arr::get($config, 'collections.posts.isSelected'),
+            'collections.posts.isSelected was NOT merged but should have been'
+        );
+        $this->assertEquals(
+            'date',
+            Arr::get($config, 'collections.posts.sort'),
+            'collections.posts.sort was NOT merged but should have been'
         );
     }
 }


### PR DESCRIPTION
This PR aims to alter how configurations are merged so that the process feels a bit more intuitive and requires less duplication of config settings between environments. The docs [lay out how configurations can be merged](https://jigsaw.tighten.co/docs/building-and-previewing-environments/), and this works fine for top-level key/value pairs. I ran into an issue, however, when I wanted to [add a filter](https://jigsaw.tighten.co/docs/collections-filtering/) to a collection so that only posts w/ a `published` metadata value were included in my production build. Doing so was easy, and just involved the following:
```php
// config.production.php
<?php

return [
    'collections' => [
        'posts' => [
            'filter' => function ($item) {
                return $item->published;
            }
        ],
    ],
];
```

However this resulted in the rest of the `collections` settings from my base `config.php` being discarded. This is because the current implementation simply does a `collect()->merge()`, which seems to only consider the top-level key/value pairs. 

The code I'm submitting alters the way that configs are merged to use `array_replace_recursive`, which should crawl through the entire config arrays (including nested arrays and Collections) and only replace the key/value pairs that are different, keeping any that have not been altered.

Example:
```php
// config.php
return [
    'baseUrl' => '',
    'production' => false,
    'siteName' => 'Blog Starter Template',
    'siteAuthor' => 'Author Name',

    // collections
    'collections' => [
        'posts' => [
            'author' => 'Author Name',
            'sort' => '-date',
            'path' => 'blog/{filename}'
        ],
    ]
];

// config.production.php
return [
    'baseUrl' => 'https://my-jigsaw-blog.com',
    'production' => true,
    'collections' => [
        'posts' => [
            'filter' => function ($item) {
                return $item->published;
            }
        ],
    ],
];

// merged config (current behavior)
// Note how collections.posts does not contain author, sort or path
[
    'baseUrl' => 'https://my-jigsaw-blog.com',
    'production' => true,
    'siteName' => 'Blog Starter Template',
    'siteAuthor' => 'Author Name',

    // collections
    'collections' => [
        'posts' => [
            'filter' => function ($item) {
                return $item->published;
            }
        ],
    ]
];

// merged config (new behavior)
// Note how collections.posts contains author, sort, path and filter
[
    'baseUrl' => 'https://my-jigsaw-blog.com',
    'production' => true,
    'siteName' => 'Blog Starter Template',
    'siteAuthor' => 'Author Name',

    // collections
    'collections' => [
        'posts' => [
            'author' => 'Author Name',
            'sort' => '-date',
            'path' => 'blog/{filename}',
            'filter' => function ($item) {
                return $item->published;
            }
        ],
    ]
];
```

Current issues needing advice:
- the `config.php` used for testing includes a function defn that triggers an error if that config is loaded more than once. As such, each individual test in the project passes but the overall suite fails b/c I needed/wanted to use that config for testing and so it's loaded in 2 different tests, which triggers the "Fatal error: cannot redeclare ...". I would like advice from project maintainers as to whether that function is important to the tests (ie it's presense is testing something), or just something incidental that could be refactored so that that loading `config.php` in different tests doesn't cause PHP to kvetch.
- if users are depending on the current behavior to discard values in "subarrays", this could introduce a breaking change
- I was aiming for minimal API changes, but I don't love some of the changes I made to achieve that. For example, making `mergeConfigs()` a static method seems to make sense, but then doing `(new static(''))->convertStringCollectionsToArray(...)` in that method in order to reuse the `convertStringCollectionsToArray()` instance method seems hacky and gross. I would also love some advice or suggestions on how to clean that up without making too big of a mess.

Because of these "issues", I've marked this PR as a "WIP". Other than these, though, it's fully functional.

Thanks so much for the great project! I hope that you'll find this change useful.