### PR TITLE
added macro trait to Jigsaw class

### DIFF
--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -2,10 +2,13 @@
 
 namespace TightenCo\Jigsaw;
 
+use Illuminate\Support\Traits\Macroable;
 use TightenCo\Jigsaw\File\Filesystem;
 
 class Jigsaw
 {
+    use Macroable;
+
     public $app;
     protected $env;
     protected $outputPaths;

--- a/tests/JigsawMacroTest.php
+++ b/tests/JigsawMacroTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests;
+
+use TightenCo\Jigsaw\Jigsaw;
+
+class JigsawMacroTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function jigsaw_macro_function_calls_successfully()
+    {
+        Jigsaw::macro('getNameMacro', function () {
+            return 'Reed';
+        });
+
+        $this->assertSame('Reed', Jigsaw::getNameMacro());
+    }
+
+    /**
+     * @test
+     */
+    public function jigsaw_mixin_function_calls_successfully()
+    {
+        Jigsaw::mixin(new JigsawMixinTestClass);
+
+        $this->assertSame('Reed', Jigsaw::getNameMixin());
+    }
+}
+
+class JigsawMixinTestClass
+{
+    public function getNameMixin()
+    {
+        return function () {
+            return 'Reed';
+        };
+    }
+}


### PR DESCRIPTION
Adding the macro trait to the Jigsaw class makes it much easier to extend and customize certain aspects of Jigsaw. For example,  I'm using my [Neocities Package](https://github.com/reed-jones/Neocities-php) which allows me to upload deploy the compiled files using the `afterBuild` event. Using the macro, I can abstract away the implementation and provide an installable plugin which can easily be used.
```php
Jigsaw::mixin(new NeocitiesJigsawDeployment);

$events->afterBuild(function (Jigsaw $jigsaw) {
    if ($jigsaw->getEnvironment() === 'production') {
        $jigsaw->deployToNeocities();
    }
});
```