### PR TITLE
added ability to customize commands

### DIFF
--- a/jigsaw
+++ b/jigsaw
@@ -4,6 +4,7 @@
 use TightenCo\Jigsaw\Console\BuildCommand;
 use TightenCo\Jigsaw\Console\InitCommand;
 use TightenCo\Jigsaw\Console\ServeCommand;
+use TightenCo\Jigsaw\Jigsaw;
 
 require_once(__DIR__ . '/jigsaw-core.php');
 
@@ -11,4 +12,5 @@ $app = new Symfony\Component\Console\Application('Jigsaw', '1.3.15');
 $app->add($container[InitCommand::class]);
 $app->add(new BuildCommand($container));
 $app->add(new ServeCommand($container));
+Jigsaw::addUserCommands($app, $container);
 $app->run();

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -189,11 +189,11 @@ $container->singleton('events', function ($c) {
     return new EventBus();
 });
 
+$container->bind(Jigsaw::class, function ($c) {
+    return new Jigsaw($c, $c[DataLoader::class], $c[CollectionRemoteItemLoader::class], $c[SiteBuilder::class]);
+});
+
 if (file_exists($bootstrapFile)) {
     $events = $container->events;
     include $bootstrapFile;
 }
-
-$container->bind(Jigsaw::class, function ($c) {
-    return new Jigsaw($c, $c[DataLoader::class], $c[CollectionRemoteItemLoader::class], $c[SiteBuilder::class]);
-});

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -13,6 +13,7 @@ class Jigsaw
     protected $dataLoader;
     protected $siteBuilder;
     protected $verbose;
+    protected static $commands = [];
 
     public function __construct($app, $dataLoader, $remoteItemLoader, $siteBuilder)
     {
@@ -33,6 +34,18 @@ class Jigsaw
             ->buildSite($useCache)
             ->fireEvent('afterBuild')
             ->cleanup();
+    }
+
+    public static function registerCommand($command)
+    {
+        self::$commands[] = $command;
+    }
+
+    public static function addUserCommands($app, $container)
+    {
+        foreach (self::$commands as $command) {
+            $app->add(new $command($container));
+        }
     }
 
     protected function buildCollections()

--- a/tests/CustomCommandTest.php
+++ b/tests/CustomCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests;
+
+use org\bovigo\vfs\vfsStream;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use TightenCo\Jigsaw\Console\Command;
+use TightenCo\Jigsaw\Jigsaw;
+
+class CustomCommandTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function custom_command_with_no_arguments()
+    {
+        $vfs = vfsStream::setup('virtual', null, []);
+        $command = $this->app->make(CustomCommand::class);
+        $command->setApplication(new Application());
+
+        $console = new CommandTester($command);
+        $console->execute([]);
+
+        $this->assertContains('Command Tested', $console->getDisplay());
+    }
+}
+
+class CustomCommand extends Command {
+    protected function fire()
+    {
+        $this->console->info("Command Tested");
+    }
+}


### PR DESCRIPTION
I'm not sure this is the best way to go about it, but I'm proposing to add the ability to create new commands under the jigsaw name. In a similar vein to my other PR (#408), however this customizes the CLI interface instead of just actions triggered on events. 

My use-case again is easier deployments.

```php
// bootstrap.php
$container->get(Jigsaw::class)->registerCommand(RunDeploymentCommand::class);
```

In my project, I extended the `BuildCommand`, renamed it to 'deploy', then after it completes the build process, I run my deploy.
```php
use TightenCo\Jigsaw\Console\BuildCommand;

class RunDeploymentCommand extends BuildCommand
{
    private $jigsaw;

    public function __construct($container)
    {
        parent::__construct($container);

        $this->jigsaw = $container->get(Jigsaw::class);
    }

    protected function configure()
    {
        parent::configure();

        // Override default name & description
        $this->setName('deploy')
            ->setDescription('Build & Deploy your site to neocities.');
    }

    protected function fire()
    {
        parent::fire();

        $env = $this->input->getArgument('env');
        $this->jigsaw->deployToNeocities(); // assumes the macro trait in PR #408 is merged
        $this->console->info("Site deployed to {$env}");
    }
}
```

```sh
./vendor/bin/jigsaw deploy production
```