### PR TITLE
Output links generated on Windows need $file->path() converted to `/`

### DIFF
--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -160,7 +160,7 @@ class SiteBuilder
         }
 
         return rightTrimPath(urldecode($this->outputPathResolver->link(
-            $file->path(),
+            str_replace('\\', '/', $file->path()),
             $file->name(),
             $file->extension(),
             $file->page()


### PR DESCRIPTION
Addresses https://github.com/tightenco/jigsaw/issues/413

When generating the array of links for all output files, `getOutputLink()` currently relies on the `$file->path()`, which may contain the directory separator `\` on Windows. This PR converts those to `/` to correctly generate a link, rather than a file path.