### PR TITLE
remove incorrect typehint from CollectionItemHandler

### DIFF
--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -12,7 +12,7 @@ class CollectionItemHandler
     private $config;
     private $handlers;
 
-    public function __construct(Collection $config, $handlers)
+    public function __construct($config, $handlers)
     {
         $this->config = $config;
         $this->handlers = collect($handlers);


### PR DESCRIPTION
Its typehinted as `Collection`, however in [jigsaw-core.php line 159](https://github.com/tightenco/jigsaw/blob/master/jigsaw-core.php#L159) an array is passed in (from `TightenCo\Jigsaw\File\ConfigFile` ).