### PR TITLE
Restore "language-" prefix for fenced code blocks

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -84,7 +84,13 @@ $container->bind('outputPathResolver', function ($c) {
 
 $container->bind(YAMLParser::class, SymfonyYAMLParser::class);
 
-$container->bind(FrontYAMLMarkdownParser::class, MarkdownParser::class);
+$container->singleton('markdownParser', function ($c) {
+    return new MarkdownParser;
+});
+
+$container->bind(FrontYAMLMarkdownParser::class, function ($c) {
+    return $c['markdownParser'];
+});
 
 $container->bind(Parser::class, function ($c) {
     return new Parser($c[YAMLParser::class], $c[FrontYAMLMarkdownParser::class]);

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -8,7 +8,7 @@ class JigsawMarkdownParser extends MarkdownExtra
 {
     public function text($text)
     {
-        return self::defaultTransform($text);
+        return $this->transform($text);
     }
 
     public function parse($text)

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -6,6 +6,12 @@ use Michelf\MarkdownExtra;
 
 class JigsawMarkdownParser extends MarkdownExtra
 {
+    public function __construct()
+    {
+        parent::__construct();
+            $this->code_class_prefix = 'language_';
+    }
+
     public function text($text)
     {
         return $this->transform($text);

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -9,7 +9,7 @@ class JigsawMarkdownParser extends MarkdownExtra
     public function __construct()
     {
         parent::__construct();
-            $this->code_class_prefix = 'language_';
+            $this->code_class_prefix = 'language-';
     }
 
     public function text($text)

--- a/src/Parsers/MarkdownParser.php
+++ b/src/Parsers/MarkdownParser.php
@@ -6,9 +6,21 @@ use Mni\FrontYAML\Markdown\MarkdownParser as FrontYAMLMarkdownParser;
 
 class MarkdownParser implements FrontYAMLMarkdownParser
 {
+    public $parser;
+
     public function __construct(JigsawMarkdownParser $parser = null)
     {
         $this->parser = $parser ?: new JigsawMarkdownParser();
+    }
+
+    public function __get($property)
+    {
+        return $this->parser->$property;
+    }
+
+    public function __set($property, $value)
+    {
+        $this->parser->$property = $value;
     }
 
     public function parse($markdown)

--- a/tests/snapshots/escape-test-hybrid/index.html
+++ b/tests/snapshots/escape-test-hybrid/index.html
@@ -118,7 +118,7 @@
 
 <p>(where _php is a .md file)</p>
 
-<pre><code class="php">ok
+<pre><code class="language_php">ok
 
 Only an issue with blade.md files:
 

--- a/tests/snapshots/escape-test-hybrid/index.html
+++ b/tests/snapshots/escape-test-hybrid/index.html
@@ -118,7 +118,7 @@
 
 <p>(where _php is a .md file)</p>
 
-<pre><code class="language_php">ok
+<pre><code class="language-php">ok
 
 Only an issue with blade.md files:
 

--- a/tests/snapshots/escape-test-markdown/index.html
+++ b/tests/snapshots/escape-test-markdown/index.html
@@ -102,7 +102,7 @@
 
 <hr>
 
-<pre><code class="language_php">&lt;?php
+<pre><code class="language-php">&lt;?php
 // Test comment...
 
 public function store()

--- a/tests/snapshots/escape-test-markdown/index.html
+++ b/tests/snapshots/escape-test-markdown/index.html
@@ -102,7 +102,7 @@
 
 <hr>
 
-<pre><code class="php">&lt;?php
+<pre><code class="language_php">&lt;?php
 // Test comment...
 
 public function store()


### PR DESCRIPTION
As referenced in https://github.com/tightenco/jigsaw/issues/424, the recent change in Markdown parsers from https://github.com/tightenco/jigsaw/pull/416 altered the default behavior for language class names applied to fenced code blocks. The previous parser (Parsedown) followed the Prism convention of prefixing language class names with `language-*`, whereas the new parser (PHP Markdown) omits the prefix.

This PR restores the previous Jigsaw behavior, to prevent breaking sites that relied on the `language-` prefix for syntax highlighting. 

In addition, since PHP Markdown exposes this setting (and others) through a series of configuration options, this PR makes those settings easily configurable in `bootstrap.php`. Specifically:

- it updates the MarkdownParser binding to use a singleton, and 
- binds the parser to a `markdownParser` key on the container

Now, any of the parser's [configuration options](https://michelf.ca/projects/php-markdown/configuration/) can be easily set in `bootstrap.php`. For example, to remove the `language-` prefix from fenced code block class names, this line can now be added to `bootstrap.php`:

```php
$container['markdownParser']->code_class_prefix = '';
```

Likewise, this PR will make it possible to include a custom function for generating IDs (as mentioned [here](https://github.com/tightenco/jigsaw/pull/416#issuecomment-580306406)).


