### PR TITLE
Improve Blade-Markdown `@` escaping

### DIFF
--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -151,9 +151,7 @@ class MarkdownHandler
 
         if (in_array($file->getFullExtension(), ['markdown', 'md', 'mdown'])) {
             $replacements = array_merge([
-                ' @' => " {{'@'}}",
-                "\n@" => "\n{{'@'}}",
-                '`@' => "`{{'@'}}",
+                '@' => "{{'@'}}",
                 '{{' => '@{{',
                 '{!!' => '@{!!',
             ], $replacements);

--- a/src/Parsers/JigsawMarkdownParser.php
+++ b/src/Parsers/JigsawMarkdownParser.php
@@ -9,7 +9,10 @@ class JigsawMarkdownParser extends MarkdownExtra
     public function __construct()
     {
         parent::__construct();
-            $this->code_class_prefix = 'language-';
+        $this->code_class_prefix = 'language-';
+        $this->url_filter_func = function ($url) {
+            return str_replace("{{'@'}}", '@', $url);
+        };
     }
 
     public function text($text)

--- a/tests/AtSymbolInMarkdownTest.php
+++ b/tests/AtSymbolInMarkdownTest.php
@@ -44,6 +44,66 @@ class AtSymbolInMarkdownTest extends TestCase
         );
     }
 
+    /**
+     * @test
+     */
+    public function at_symbol_after_closing_bracket_is_unchanged_in_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.md' => $this->getYamlHeader() .
+                "<p>@include('foo')</p>"
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            "<div><p>@include('foo')</p></div>",
+            $this->clean($files->getChild('build/test.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function double_at_symbol_in_fenced_code_block_is_parsed_to_single_at_symbol_in_blade_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.blade.md' => $this->getYamlHeader() .
+                "```\n@@if(true)<h1>Foo</h1>@@endif\n```"
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><pre><code>@if(true)&lt;h1&gt;Foo&lt;/h1&gt;@endif</code></pre></div>',
+            $this->clean($files->getChild('build/test.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function double_at_symbol_in_inline_code_block_is_parsed_to_single_at_symbol_in_blade_markdown()
+    {
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+            'test.blade.md' => $this->getYamlHeader() .
+                "`@@if(true)<h1>Foo</h1>@@endif`"
+        ]);
+        $this->buildSite($files);
+
+        $this->assertEquals(
+            '<div><p><code>@if(true)&lt;h1&gt;Foo&lt;/h1&gt;@endif</code></p></div>',
+            $this->clean($files->getChild('build/test.html')->getContent())
+        );
+    }
+
     public function getYamlHeader()
     {
         return implode("\n", ['---', 'extends: _layouts.master', 'section: content', '---', '']);


### PR DESCRIPTION
This PR simplifies the escaping of the `@` symbol in markdown files, removing special cases that were intended to catch most occurrences but preserve `@` in the case of `mailto:` links. The recent switch of the markdown parser to use PHP Markdown library enables us to use a callback for formatting URLs, in which we can undo the Blade escaping that was added in `MarkdownHandler`.