### PR TITLE
Expose source file info to afterBuild event

### DIFF
--- a/src/File/CopyFile.php
+++ b/src/File/CopyFile.php
@@ -6,10 +6,10 @@ class CopyFile extends OutputFile
 {
     protected $source;
 
-    public function __construct($source, $path, $name, $extension, $data, $page = 1)
+    public function __construct($file, $source, $path, $name, $extension, $data, $page = 1)
     {
         $this->source = $source;
-        parent::__construct($path, $name, $extension, null, $data, $page);
+        parent::__construct($file, $path, $name, $extension, null, $data, $page);
     }
 
     public function putContents($destination)

--- a/src/File/CopyFile.php
+++ b/src/File/CopyFile.php
@@ -2,11 +2,13 @@
 
 namespace TightenCo\Jigsaw\File;
 
+use TightenCo\Jigsaw\File\InputFile;
+
 class CopyFile extends OutputFile
 {
     protected $source;
 
-    public function __construct($file, $source, $path, $name, $extension, $data, $page = 1)
+    public function __construct(InputFile $file, $source, $path, $name, $extension, $data, $page = 1)
     {
         $this->source = $source;
         parent::__construct($file, $path, $name, $extension, null, $data, $page);

--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -16,6 +16,11 @@ class InputFile
         $this->file = $file;
     }
 
+    public function getFileInfo()
+    {
+        return $this->file;
+    }
+
     public function topLevelDirectory()
     {
         $parts = explode(DIRECTORY_SEPARATOR, $this->file->getRelativePathName());

--- a/src/File/OutputFile.php
+++ b/src/File/OutputFile.php
@@ -2,8 +2,11 @@
 
 namespace TightenCo\Jigsaw\File;
 
+use TightenCo\Jigsaw\File\InputFile;
+
 class OutputFile
 {
+    private $inputFile;
     private $path;
     private $name;
     private $extension;
@@ -11,14 +14,20 @@ class OutputFile
     private $data;
     private $page;
 
-    public function __construct($path, $name, $extension, $contents, $data, $page = 1)
+    public function __construct(InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1)
     {
+        $this->inputFile = $inputFile;
         $this->path = $path;
         $this->name = $name;
         $this->extension = $extension;
         $this->contents = $contents;
         $this->data = $data;
         $this->page = $page;
+    }
+
+    public function inputFile()
+    {
+        return $this->inputFile;
     }
 
     public function path()

--- a/src/Handlers/BladeHandler.php
+++ b/src/Handlers/BladeHandler.php
@@ -48,6 +48,7 @@ class BladeHandler
 
         return collect([
             new OutputFile(
+                $file,
                 $file->getRelativePath(),
                 $file->getFilenameWithoutExtension(),
                 $extension == 'php' ? 'html' : $extension,

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -53,7 +53,7 @@ class CollectionItemHandler
         }
 
         return $handler->handleCollectionItem($file, $pageData)
-            ->map(function ($outputFile, $templateToExtend) {
+            ->map(function ($outputFile, $templateToExtend) use ($file) {
                 if ($templateToExtend) {
                     $outputFile->data()->setExtending($templateToExtend);
                 }
@@ -61,6 +61,7 @@ class CollectionItemHandler
                 $path = $outputFile->data()->page->getPath();
 
                 return new OutputFile(
+                    $file,
                     dirname($path),
                     basename($path, '.' . $outputFile->extension()),
                     $outputFile->extension(),

--- a/src/Handlers/DefaultHandler.php
+++ b/src/Handlers/DefaultHandler.php
@@ -23,6 +23,7 @@ class DefaultHandler
     {
         return collect([
             new CopyFile(
+                $file,
                 $file->getPathName(),
                 $file->getRelativePath(),
                 $file->getBasename('.' . $file->getExtension()),

--- a/src/Handlers/MarkdownHandler.php
+++ b/src/Handlers/MarkdownHandler.php
@@ -54,6 +54,7 @@ class MarkdownHandler
                 $extension = $this->view->getExtension($extends);
 
                 return new OutputFile(
+                    $file,
                     $file->getRelativePath(),
                     $file->getFileNameWithoutExtension(),
                     $extension == 'php' ? 'html' : $extension,

--- a/src/Handlers/PaginatedPageHandler.php
+++ b/src/Handlers/PaginatedPageHandler.php
@@ -53,6 +53,7 @@ class PaginatedPageHandler
             $extension = strtolower($file->getExtension());
 
             return new OutputFile(
+                $file,
                 $file->getRelativePath(),
                 $file->getFilenameWithoutExtension(),
                 $extension == 'php' ? 'html' : $extension,

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -70,13 +70,15 @@ class Jigsaw
 
     protected function buildSite($useCache)
     {
-        $this->outputPaths = $this->siteBuilder
+        $output = $this->siteBuilder
             ->setUseCache($useCache)
             ->build(
                 $this->getSourcePath(),
                 $this->getDestinationPath(),
                 $this->siteData
             );
+
+        $this->outputPaths = $output->keys();
 
         return $this;
     }

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -14,6 +14,7 @@ class Jigsaw
 
     public $app;
     protected $env;
+    protected $sourceFileInfo;
     protected $outputPaths;
     protected $siteData;
     protected $dataLoader;
@@ -70,15 +71,14 @@ class Jigsaw
 
     protected function buildSite($useCache)
     {
-        $output = $this->siteBuilder
+        $this->sourceFileInfo = $this->siteBuilder
             ->setUseCache($useCache)
             ->build(
                 $this->getSourcePath(),
                 $this->getDestinationPath(),
                 $this->siteData
             );
-
-        $this->outputPaths = $output->keys();
+        $this->outputPaths = $this->sourceFileInfo->keys();
 
         return $this;
     }
@@ -167,9 +167,14 @@ class Jigsaw
         return $this->app->make(Filesystem::class);
     }
 
+    public function getSourceFileInfo()
+    {
+        return $this->sourceFileInfo ?: collect();
+    }
+
     public function getOutputPaths()
     {
-        return $this->outputPaths ?: [];
+        return $this->outputPaths ?: collect();
     }
 
     public function readSourceFile($fileName)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -97,8 +97,10 @@ class SiteBuilder
     {
         $this->consoleOutput->writeWritingFiles();
 
-        return $files->map(function ($file) use ($destination) {
-            return $this->writeFile($file, $destination);
+        return $files->mapWithKeys(function ($file) use ($destination) {
+            $outputLink = $this->writeFile($file, $destination);
+
+            return [$outputLink => $file->inputFile()];
         });
     }
 

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -219,7 +219,7 @@ class CollectionItemTest extends TestCase
         $this->buildSite($files, $config, $pretty = true);
 
         $this->assertEquals(
-            $this->clean($files->getChild('build/collection/page/index.html')->filemtime()),
+            $files->getChild('build/collection/page/index.html')->filemtime(),
             $this->clean($files->getChild('build/collection/page/index.html')->getContent())
         );
     }

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -130,8 +130,62 @@ class SiteBuilderTest extends TestCase
         $this->buildSite($files, [], $pretty = true);
 
         $this->assertEquals(
-            $this->clean($files->getChild('build/page/index.html')->filemtime()),
+            $files->getChild('build/page/index.html')->filemtime(),
             $this->clean($files->getChild('build/page/index.html')->getContent())
         );
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_output_paths_after_building_site()
+    {
+        $files = $this->setupSource([
+            'page1.blade.php' => 'Page 1',
+            'nested' => [
+                'page2.blade.php' => 'Page 2',
+            ],
+        ]);
+        $jigsaw = $this->buildSite($files, [], $pretty = true);
+
+        $this->assertEquals(
+            [
+                '/page1',
+                '/nested/page2',
+            ],
+            $jigsaw->getOutputPaths()->toArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_source_file_info_after_building_site()
+    {
+        $files = $this->setupSource([
+            'page1.blade.php' => 'Page 1',
+            'nested' => [
+                'page2.blade.php' => 'Page Two',
+            ],
+        ]);
+        $jigsaw = $this->buildSite($files, [], $pretty = true);
+
+        $source1 = $jigsaw->getSourceFileInfo()->get('/page1');
+        $this->assertEquals(
+            $files->getChild('build/page1/index.html')->filemtime(),
+            $source1->getLastModifiedTime()
+        );
+        $this->assertEquals('page1.blade.php', $source1->getFilename());
+        $this->assertTrue($source1->isBladeFile());
+        $this->assertEquals(6, $source1->getSize());
+
+        $source2 = $jigsaw->getSourceFileInfo()->get('/nested/page2');
+        $this->assertEquals(
+            $files->getChild('build/nested/page2/index.html')->filemtime(),
+            $source2->getLastModifiedTime()
+        );
+        $this->assertEquals('page2.blade.php', $source2->getFilename());
+        $this->assertTrue($source2->isBladeFile());
+        $this->assertEquals(8, $source2->getSize());
     }
 }


### PR DESCRIPTION
This PR adds a `getSourceFileInfo()` method to the Jigsaw class, for reference during the `afterBuild` event. 

`getSourceFileInfo()` returns a collection of all output files that were generated. For each item:
- the key contains the path of the output file relative to the `build` directory (e.g. `/posts/my-first-post`)
- the value contains the Jigsaw `InputFile` object for the source file. On `InputFile`, every method from PHP's [SplFileInfo](https://www.php.net/manual/en/class.splfileinfo.php) class is available.

This is similar to `getOutputPaths()`, which returns just the output paths (i.e., the keys from `getSourceFileInfo()`).
