### PR TITLE
Return PageData in getPages() method during afterBuild event

### DIFF
--- a/src/File/InputFile.php
+++ b/src/File/InputFile.php
@@ -3,6 +3,7 @@
 namespace TightenCo\Jigsaw\File;
 
 use Illuminate\Support\Str;
+use TightenCo\Jigsaw\PageData;
 
 class InputFile
 {
@@ -10,10 +11,21 @@ class InputFile
     protected $extraBladeExtensions = [
         'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
+    protected $pageData;
 
     public function __construct($file)
     {
         $this->file = $file;
+    }
+
+    public function setPageData(PageData $pageData)
+    {
+        $this->pageData = $pageData->page;
+    }
+
+    public function getPageData()
+    {
+        return $this->pageData;
     }
 
     public function getFileInfo()

--- a/src/File/OutputFile.php
+++ b/src/File/OutputFile.php
@@ -3,6 +3,7 @@
 namespace TightenCo\Jigsaw\File;
 
 use TightenCo\Jigsaw\File\InputFile;
+use TightenCo\Jigsaw\PageData;
 
 class OutputFile
 {
@@ -16,13 +17,19 @@ class OutputFile
 
     public function __construct(InputFile $inputFile, $path, $name, $extension, $contents, $data, $page = 1)
     {
-        $this->inputFile = $inputFile;
+        $this->setInputFile($inputFile, $data);
         $this->path = $path;
         $this->name = $name;
         $this->extension = $extension;
         $this->contents = $contents;
         $this->data = $data;
         $this->page = $page;
+    }
+
+    public function setInputFile(InputFile $inputFile, PageData $data)
+    {
+        $this->inputFile = $inputFile;
+        $this->inputFile->setPageData($data);
     }
 
     public function inputFile()

--- a/src/Jigsaw.php
+++ b/src/Jigsaw.php
@@ -14,7 +14,7 @@ class Jigsaw
 
     public $app;
     protected $env;
-    protected $sourceFileInfo;
+    protected $pageInfo;
     protected $outputPaths;
     protected $siteData;
     protected $dataLoader;
@@ -71,14 +71,14 @@ class Jigsaw
 
     protected function buildSite($useCache)
     {
-        $this->sourceFileInfo = $this->siteBuilder
+        $this->pageInfo = $this->siteBuilder
             ->setUseCache($useCache)
             ->build(
                 $this->getSourcePath(),
                 $this->getDestinationPath(),
                 $this->siteData
             );
-        $this->outputPaths = $this->sourceFileInfo->keys();
+        $this->outputPaths = $this->pageInfo->keys();
 
         return $this;
     }
@@ -167,14 +167,14 @@ class Jigsaw
         return $this->app->make(Filesystem::class);
     }
 
-    public function getSourceFileInfo()
-    {
-        return $this->sourceFileInfo ?: collect();
-    }
-
     public function getOutputPaths()
     {
         return $this->outputPaths ?: collect();
+    }
+
+    public function getPages()
+    {
+        return $this->pageInfo ?: collect();
     }
 
     public function readSourceFile($fileName)

--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -100,7 +100,7 @@ class SiteBuilder
         return $files->mapWithKeys(function ($file) use ($destination) {
             $outputLink = $this->writeFile($file, $destination);
 
-            return [$outputLink => $file->inputFile()];
+            return [$outputLink => $file->inputFile()->getPageData()];
         });
     }
 

--- a/tests/SiteBuilderTest.php
+++ b/tests/SiteBuilderTest.php
@@ -160,32 +160,33 @@ class SiteBuilderTest extends TestCase
     /**
      * @test
      */
-    public function can_get_source_file_info_after_building_site()
+    public function can_get_collection_of_page_info_after_building_site()
     {
         $files = $this->setupSource([
             'page1.blade.php' => 'Page 1',
             'nested' => [
-                'page2.blade.php' => 'Page Two',
+                'page2.blade.php' => "---\nfoo: bar\n---\nPage Two",
             ],
         ]);
         $jigsaw = $this->buildSite($files, [], $pretty = true);
 
-        $source1 = $jigsaw->getSourceFileInfo()->get('/page1');
+        $source1 = $jigsaw->getPages()->get('/page1');
         $this->assertEquals(
             $files->getChild('build/page1/index.html')->filemtime(),
-            $source1->getLastModifiedTime()
+            $source1->getModifiedTime()
         );
-        $this->assertEquals('page1.blade.php', $source1->getFilename());
-        $this->assertTrue($source1->isBladeFile());
-        $this->assertEquals(6, $source1->getSize());
+        $this->assertEquals('page1', $source1->getFilename());
+        $this->assertEquals('/page1', $source1->getPath());
+        $this->assertEquals('blade.php', $source1->getExtension());
 
-        $source2 = $jigsaw->getSourceFileInfo()->get('/nested/page2');
+        $source2 = $jigsaw->getPages()->get('/nested/page2');
         $this->assertEquals(
             $files->getChild('build/nested/page2/index.html')->filemtime(),
-            $source2->getLastModifiedTime()
+            $source2->getModifiedTime()
         );
-        $this->assertEquals('page2.blade.php', $source2->getFilename());
-        $this->assertTrue($source2->isBladeFile());
-        $this->assertEquals(8, $source2->getSize());
+        $this->assertEquals('page2', $source2->getFilename());
+        $this->assertEquals('/nested/page2', $source2->getPath());
+        $this->assertEquals('blade.php', $source2->getExtension());
+        $this->assertEquals('bar', $source2->foo);
     }
 }


### PR DESCRIPTION
This revises #429 

This PR changes the `getSourceFileInfo()` that was made accessible during the `afterBuild` event to `getPages()`. 

Now, instead of returning the `InputFile` as the value of each item in the collection, it returns the `PageData`, so it mimics what is available to the `$page` variable inside a template. 

This means that the `afterBuild` event now has access to any variables defined on a page (which addresses #337), as well as the [metadata helper functions](https://jigsaw.tighten.co/docs/page-metadata/) like `getPath()` and `getModifiedTime()` for each page.

