### PR TITLE
Remove empty temp remote collection folders after build

### DIFF
--- a/src/Loaders/CollectionRemoteItemLoader.php
+++ b/src/Loaders/CollectionRemoteItemLoader.php
@@ -40,17 +40,9 @@ class CollectionRemoteItemLoader
         collect($this->tempDirectories)->each(function ($path) {
             $this->files->deleteDirectory($path);
 
-            $tempParent = $this->files->dirname($path);
-            if ( $this->files->isDirectory($tempParent) ) {
-                // Get all files in this directory.
-                $files = $this->files->files($tempParent);
-                // Check if directory is empty.
-                if (empty($files)) {
-                    // Yes, delete the directory.
-                    $this->files->deleteDirectory($tempParent);
-                }
-
-              }
+            if ($this->files->isEmptyDirectory($parent = $this->files->dirname($path))) {
+                $this->files->deleteDirectory($parent);
+            }
         });
     }
 

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -177,8 +177,34 @@ class RemoteCollectionsTest extends TestCase
         ]);
         $this->buildSite($files, $config);
 
-        $this->assertCount(0, $files->getChild('source/_test')->getChildren());
         $this->assertNull($files->getChild('source/_test/_tmp'));
+    }
+
+    /**
+     * @test
+     */
+    public function temporary_parent_directory_for_remote_items_is_removed_if_empty_after_build_is_complete()
+    {
+        $config = collect([
+            'collections' => [
+                'test' => [
+                    'items' => [
+                        [
+                            'extends' => '_layouts.master',
+                            'content' => 'item content',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+        ]);
+        $this->buildSite($files, $config);
+
+        $this->assertNull($files->getChild('source/_test'));
     }
 
     /**


### PR DESCRIPTION
I use a number of remote collections and after builds (even successful builds), the `source` folder is filled with all the newly created empty `_collection_name` folders. Looks like cleanup routine clears the `_tmp` folders created, but not their empty parents.

Related to issue #289 