### PR TITLE
Allow leading periods in path names

### DIFF
--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -12,7 +12,7 @@ use Symfony\Component\VarDumper\VarDumper;
  */
 function leftTrimPath($path)
 {
-    return ltrim($path, ' .\\/');
+    return ltrim($path, ' \\/');
 }
 
 function rightTrimPath($path)

--- a/tests/FilePathTest.php
+++ b/tests/FilePathTest.php
@@ -49,6 +49,16 @@ class FilePathTest extends TestCase
         $this->assertEquals('/has-invalid-characters', $outputPath[0]);
     }
 
+    public function test_leading_periods_are_not_removed()
+    {
+        $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());
+        $pathResolver = $this->app->make(CollectionPathResolver::class);
+        $pageVariable = $this->getPageVariableDummy('.well-known');
+        $outputPath = $pathResolver->link(null, $pageVariable);
+
+        $this->assertEquals('/.well-known', $outputPath[0]);
+    }
+
     public function test_invalid_characters_in_filename_are_removed_when_using_shorthand_path_config()
     {
         $this->app->instance('outputPathResolver', new PrettyOutputPathResolver());

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -25,4 +25,12 @@ class HelpersTest extends TestCase
 
         $this->assertEquals('src/some-file.md', public_path('some-file.md'));
     }
+
+    /**
+     * @test
+     */
+    public function leftTrimPath_leaves_leading_periods()
+    {
+        $this->assertEquals('.well-known', leftTrimPath('.well-known'));
+    }
 }


### PR DESCRIPTION
The leftTrimPath helper was errantly removing leading periods from
file/directory names for paths. This is illustrated by the `.well-known`
subdirectory (https://tools.ietf.org/html/rfc8615) used by certain
apps/services to validate site-wide metadata. Without this change
including a directory in the source directory named `.well-known` will
be built into `build/well-known` which will not work in the published
site.