### PR TITLE
Added support for mapping over collection inside of config

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -26,6 +26,7 @@ class Collection extends BaseCollection
         $sortedItems = $this
             ->defaultSort($items)
             ->filter($this->getFilter())
+            ->map($this->getMap())
             ->keyBy(function ($item) {
                 return $item->getFilename();
             });
@@ -64,6 +65,19 @@ class Collection extends BaseCollection
 
         return function ($item) {
             return true;
+        };
+    }
+
+    private function getMap()
+    {
+        $map = Arr::get($this->settings, 'map');
+
+        if ($map) {
+            return $map;
+        }
+
+        return function ($item) {
+            return $item;
         };
     }
 

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -25,8 +25,8 @@ class Collection extends BaseCollection
     {
         $sortedItems = $this
             ->defaultSort($items)
-            ->filter($this->getFilter())
             ->map($this->getMap())
+            ->filter($this->getFilter())
             ->keyBy(function ($item) {
                 return $item->getFilename();
             });


### PR DESCRIPTION
As with the `filter` config option, this pull request adds support for mapping over the items after filtering.

It would be done like this:

```php
return [
    'collections' => [
        'posts' => [
            'map' => function ($post) {
                return new Post($post);
            }
        ],
    ]
]
```

The example above would let you map the collection to a data object for example, where you could place larger helper methods.

If not sure which way round makes more sense, whether the items should be mapped and then filtered, or filtered then mapped. Mapping after makes sense since it might be a longer mapping process / more resource consumption.