### PR TITLE
Allow access to config variables in remote collection callback

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -202,7 +202,7 @@ $container->bind(SiteBuilder::class, function ($c) use ($cachePath) {
 });
 
 $container->bind(CollectionRemoteItemLoader::class, function ($c) {
-    return new CollectionRemoteItemLoader(new Filesystem);
+    return new CollectionRemoteItemLoader($c['config'], new Filesystem);
 });
 
 $container->singleton('events', function ($c) {

--- a/src/Loaders/CollectionRemoteItemLoader.php
+++ b/src/Loaders/CollectionRemoteItemLoader.php
@@ -2,16 +2,19 @@
 
 namespace TightenCo\Jigsaw\Loaders;
 
+use Illuminate\Support\Collection;
 use TightenCo\Jigsaw\Collection\CollectionRemoteItem;
 use TightenCo\Jigsaw\File\Filesystem;
 
 class CollectionRemoteItemLoader
 {
+    private $config;
     private $files;
     private $tempDirectories;
 
-    public function __construct(Filesystem $files)
+    public function __construct(Collection $config, Filesystem $files)
     {
+        $this->config = $config;
         $this->files = $files;
     }
 
@@ -53,7 +56,7 @@ class CollectionRemoteItemLoader
         }
 
         return is_callable($collection->items) ?
-            $collection->items->__invoke() :
+            $collection->items->__invoke($this->config) :
             $collection->items->toArray();
     }
 

--- a/tests/RemoteCollectionsTest.php
+++ b/tests/RemoteCollectionsTest.php
@@ -488,6 +488,37 @@ class RemoteCollectionsTest extends TestCase
     /**
      * @test
      */
+    public function items_function_can_access_other_config_variables()
+    {
+        $config = collect([
+            'collections' => [
+                'test' => [
+                    'extends' => '_layouts.master',
+                    'items' => function ($config) {
+                        return [
+                            ['content' => $config['remote_url']],
+                        ];
+                    },
+                ],
+            ],
+            'remote_url' => 'https://example.com/api',
+        ]);
+        $files = $this->setupSource([
+            '_layouts' => [
+                'master.blade.php' => "<div>@yield('content')</div>",
+            ],
+        ]);
+        $this->buildSite($files, $config);
+
+        $this->assertEquals(
+            '<div><p>https://example.com/api</p></div>',
+            $this->clean($files->getChild('build/test/test-1.html')->getContent())
+        );
+    }
+
+    /**
+     * @test
+     */
     public function items_key_in_config_can_be_a_function_that_returns_a_collection()
     {
         $config = collect([


### PR DESCRIPTION
This PR passes the config array to a callback that is used in the `items` setting of a remote collection. 

It allows the `items` callback to reference other config variables, allowing an easier way to reference different API URLs, for example, in local and production environments. (Addresses #361)