### PR TITLE
use Process::fromShellCommandline instead of constructor

### DIFF
--- a/src/Scaffold/ProcessRunner.php
+++ b/src/Scaffold/ProcessRunner.php
@@ -23,7 +23,7 @@ class ProcessRunner
     protected function runCommand($command)
     {
         echo "\n> " . $command . "\n";
-        $process = new Process($command);
+        $process = Process::fromShellCommandline($command);
         $process->setTimeout(3600);
         $process->setIdleTimeout(120);
 


### PR DESCRIPTION
> ./vendor/bin/jigsaw init docs

`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in vendor/tightenco/jigsaw/src/Scaffold/ProcessRunner.php`