### PR TITLE
Add `fromItem` named constructor to CollectionItem

### DIFF
--- a/src/Collection/CollectionItem.php
+++ b/src/Collection/CollectionItem.php
@@ -6,7 +6,7 @@ use TightenCo\Jigsaw\PageVariable;
 
 class CollectionItem extends PageVariable
 {
-    private $collection;
+    public $collection;
 
     public static function build(Collection $collection, $data)
     {
@@ -14,6 +14,14 @@ class CollectionItem extends PageVariable
         $item->collection = $collection;
 
         return $item;
+    }
+
+    public static function fromItem(CollectionItem $item)
+    {
+        $newItem = new static($item);
+        $newItem->collection = $item->collection;
+
+        return $newItem;
     }
 
     public function getNext()

--- a/tests/CollectionItemTest.php
+++ b/tests/CollectionItemTest.php
@@ -91,7 +91,7 @@ class CollectionItemTest extends TestCase
                 'collection' => [
                     'path' => 'collection/{filename}',
                     'map' => function ($item) {
-                        return new MappedItem($item);
+                        return MappedItem::fromItem($item);
                     }
                 ]
             ]


### PR DESCRIPTION
This PR adds a static `forItem` method as a named constructor on CollectionItem, for use when instantiating decorated collection item classes while mapping (from #447). It correctly sets the `collection` variable on the new class, so collection-related methods (like `getNext()`, `getPrevious()`, etc.) will function correctly.