### PR TITLE
Fix .env files due to breaking change on vlucas/phpdotenv 4.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+JIGSAW_TEST_VAR=true

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -59,7 +59,7 @@ $container->setInstance($container);
 $container->instance('cwd', getcwd());
 
 if (file_exists($envPath = $container['cwd'] . '/.env')) {
-    (Dotenv::create($container['cwd']))->load();
+    (Dotenv::createImmutable($container['cwd']))->load();
 }
 
 $cachePath = $container['cwd'] . '/cache';

--- a/tests/ConfigVariableTest.php
+++ b/tests/ConfigVariableTest.php
@@ -29,8 +29,7 @@ class ConfigVariableTest extends TestCase
      */
     public function config_variables_are_loaded_from_dotenv_if_present()
     {
-        $_ENV['JIGSAW_TEST_VAR'] = true;
-        $config = (new ConfigFile($this->app['cwd'] . '/tests/config.php'))->config;
+        $config = (new ConfigFile($this->app['cwd'].'/tests/config.php'))->config;
 
         $this->assertTrue($config['envVariable']);
     }


### PR DESCRIPTION
The latest upgrade to vlucas/phpdotenv 4.0 broke using .env files, because of a breaking change made from 3 -> 4: https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md#v3-to-v4

This fixes the issue and changes the test to use an actual .env file.