### PR TITLE
collect config during initial creation

### DIFF
--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -72,9 +72,8 @@ $container->instance('buildPath', [
 
 $container->bind('config', function ($c) use ($cachePath) {
     $config = (new ConfigFile($c['cwd'] . '/config.php', $c['cwd'] . '/helpers.php'))->config;
-    $config['view.compiled'] = $cachePath;
-
-    return collect($config);
+    $config->put('view.compiled', $cachePath);
+    return $config;
 });
 
 $container->singleton('consoleOutput', function ($c) {

--- a/jigsaw-core.php
+++ b/jigsaw-core.php
@@ -74,7 +74,7 @@ $container->bind('config', function ($c) use ($cachePath) {
     $config = (new ConfigFile($c['cwd'] . '/config.php', $c['cwd'] . '/helpers.php'))->config;
     $config['view.compiled'] = $cachePath;
 
-    return $config;
+    return collect($config);
 });
 
 $container->singleton('consoleOutput', function ($c) {

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -75,7 +75,7 @@ class BuildCommand extends Command
         $environmentConfigPath = $this->getAbsolutePath("config.{$env}.php");
         $environmentConfig = (new ConfigFile($environmentConfigPath))->config;
 
-        $this->app->config = collect($this->app->config)
+        $this->app->config = $this->app->config
             ->merge(collect($environmentConfig))
             ->filter(function ($item) {
                 return $item !== null;

--- a/src/File/ConfigFile.php
+++ b/src/File/ConfigFile.php
@@ -2,29 +2,27 @@
 
 namespace TightenCo\Jigsaw\File;
 
-use Illuminate\Support\Arr;
-
 class ConfigFile
 {
     public $config;
 
-    public function __construct($config_path, $helpers_path = '')
+    public function __construct(string $config_path, string $helpers_path = '')
     {
         $config = file_exists($config_path) ? include $config_path : [];
         $helpers = file_exists($helpers_path) ? include $helpers_path : [];
 
-        $this->config = array_merge($config, $helpers);
+        $this->config = collect($config)->merge($helpers);
         $this->convertStringCollectionsToArray();
     }
 
     protected function convertStringCollectionsToArray()
     {
-        $collections = Arr::get($this->config, 'collections');
+        $collections = $this->config->get('collections');
 
         if ($collections) {
-            $this->config['collections'] = collect($collections)->flatMap(function ($value, $key) {
+            $this->config->put('collections', collect($collections)->flatMap(function ($value, $key) {
                 return is_array($value) ? [$key => $value] : [$value => []];
-            });
+            }));
         }
     }
 }

--- a/src/Handlers/CollectionItemHandler.php
+++ b/src/Handlers/CollectionItemHandler.php
@@ -12,7 +12,7 @@ class CollectionItemHandler
     private $config;
     private $handlers;
 
-    public function __construct($config, $handlers)
+    public function __construct(Collection $config, $handlers)
     {
         $this->config = $config;
         $this->handlers = collect($handlers);

--- a/src/Loaders/DataLoader.php
+++ b/src/Loaders/DataLoader.php
@@ -2,6 +2,7 @@
 
 namespace TightenCo\Jigsaw\Loaders;
 
+use Illuminate\Support\Collection;
 use TightenCo\Jigsaw\SiteData;
 
 class DataLoader
@@ -13,7 +14,7 @@ class DataLoader
         $this->collectionDataLoader = $collectionDataLoader;
     }
 
-    public function loadSiteData($config)
+    public function loadSiteData(Collection $config)
     {
         return SiteData::build($config);
     }

--- a/src/View/ViewRenderer.php
+++ b/src/View/ViewRenderer.php
@@ -2,6 +2,7 @@
 
 namespace TightenCo\Jigsaw\View;
 
+use Illuminate\Support\Collection;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
 
@@ -21,9 +22,9 @@ class ViewRenderer
         'js', 'json', 'xml', 'rss', 'atom', 'txt', 'text', 'html',
     ];
 
-    public function __construct(Factory $viewFactory, BladeCompiler $bladeCompiler, $config = [])
+    public function __construct(Factory $viewFactory, BladeCompiler $bladeCompiler, Collection $config = null)
     {
-        $this->config = collect($config);
+        $this->config = $config ?? collect();
         $this->viewFactory = $viewFactory;
         $this->bladeCompiler = $bladeCompiler;
         $this->finder = $this->viewFactory->getFinder();

--- a/tests/ViewRendererTest.php
+++ b/tests/ViewRendererTest.php
@@ -18,11 +18,11 @@ class ViewRendererTest extends TestCase
         $mock->shouldReceive('getFinder');
         $mock->shouldReceive('addNamespace')->with('view::hint', 'path');
         $mock->shouldReceive('addExtension');
-        new ViewRenderer($mock, Mockery::mock(BladeCompiler::class), [
+        new ViewRenderer($mock, Mockery::mock(BladeCompiler::class), collect([
             'viewHintPaths' => [
                 'view::hint' => 'path'
             ]
-        ]);
+        ]));
 
         $this->addToAssertionCount(
             Mockery::getContainer()->mockery_getExpectationCount()
@@ -54,9 +54,9 @@ class ViewRendererTest extends TestCase
         $mock->shouldReceive('getFinder');
         $mock->shouldNotReceive('addNamespace')->with('view::hint', 'path');
         $mock->shouldReceive('addExtension');
-        new ViewRenderer($mock, Mockery::mock(BladeCompiler::class), [
+        new ViewRenderer($mock, Mockery::mock(BladeCompiler::class), collect([
             'viewHintPaths' => []
-        ]);
+        ]));
 
         $this->addToAssertionCount(
             Mockery::getContainer()->mockery_getExpectationCount()


### PR DESCRIPTION
I noticed the config was initially being created as an array in ConfigFile, however in some places it was being used as a Collection instead (the Constructor for CollectionRemoteItemLoader). I previously fixed a very similar bug https://github.com/tightenco/jigsaw/pull/423 and was tempted to remove the typehint again, but after a little digging I found what what happening.

in `BuildCommand`->`includeEnvironmentConfig` It actually overwrites the original array config with a new collection config. This fix just makes it a collection from the start, (and undoes my previous typehint removal)