### PR TITLE
Prefix test build commands with `php` for Windows compatibility.

### DIFF
--- a/tests/SnapshotTestCase.php
+++ b/tests/SnapshotTestCase.php
@@ -16,7 +16,7 @@ class SnapshotTestCase extends BaseTestCase
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
-        echo shell_exec('./jigsaw build testing -q');
+        echo shell_exec('php ./jigsaw build testing -q');
     }
 
     public static function tearDownAfterClass()

--- a/tests/rebuild.php
+++ b/tests/rebuild.php
@@ -4,7 +4,7 @@
  * To rebuild the `snapshots` directory after changing
  * files in `source`, run `php tests/rebuild.php`.
  */
-shell_exec('./jigsaw build testing');
+shell_exec('php ./jigsaw build testing');
 removeDirectory('tests/snapshots');
 rename('tests/build-testing', 'tests/snapshots');
 


### PR DESCRIPTION
PHPUnit setup was not able to execute `./jigsaw` directly. Prefixing it with `php` fixes this issue on Windows.

Please test this on macOS and Linux.